### PR TITLE
Add CAREGIVER_APP_BUNDLE_IDENTIFIER to LoopConfigOverride.xcconfig

### DIFF
--- a/LoopConfigOverride.xcconfig
+++ b/LoopConfigOverride.xcconfig
@@ -3,6 +3,9 @@
 // Override this if you don't want the default com.${DEVELOPMENT_TEAM}.loopkit that loop uses
 // MAIN_APP_BUNDLE_IDENTIFIER = com.myname.loop
 
+// Customize this if you don't want the default com.${DEVELOPMENT_TEAM}.loopkit.LoopCaregiver that caregiver uses
+// CAREGIVER_APP_BUNDLE_IDENTIFIER = com.myname.loopcaregiver
+
 // Customize this to change the app name displayed
 //MAIN_APP_DISPLAY_NAME = Loop
 


### PR DESCRIPTION
Adds a template `CAREGIVER_APP_BUNDLE_IDENTIFIER` to the `LoopConfigOverride.xcconfig` file to address #5. It is/was known that the `MAIN_APP_BUNDLE_IDENTIFIER` was only used by Loop and not used by LoopCaregiver, but the `LoopConfigOverride.xcconfig` from LoopWorkspace was left untouched, since the idea is that you can use the same .xcconfig to build both Loop and LoopCaregiver.

In any case, there's no harm adding an example `CAREGIVER_APP_BUNDLE_IDENTIFIER` to the `LoopConfigOverride.xcconfig` in this repository.