### PR TITLE
Updated view for clearer required fields

### DIFF
--- a/LoopCaregiver/LoopCaregiver/Views/Settings/LooperSetupView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Settings/LooperSetupView.swift
@@ -60,36 +60,52 @@ struct LooperSetupView: View {
     private var inputFormView: some View {
         Form {
             Section {
-                TextField(
-                    "Name",
-                    text: $nameFieldText, onCommit:
-                        {
-                            self.save()
-                        })
-                .autocapitalization(.none)
-                .disableAutocorrection(true)
-                TextField(
-                    "Nightscout URL",
-                    text: $nightscoutURLFieldText, onCommit:
-                        {
-                            self.save()
-                        })
-                .autocapitalization(.none)
-                .disableAutocorrection(true)
-                TextField(
-                    "API Secret",
-                    text: $apiSecretFieldText
-                ) {
-                    self.save()
+                VStack {
+                    Text("Name")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    TextField(
+                        "Required",
+                        text: $nameFieldText, onCommit:
+                            {
+                                self.save()
+                            })
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)
                 }
-                .autocapitalization(.none)
-                .disableAutocorrection(true)
+                VStack{
+                    Text("Nightscout URL")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    TextField(
+                        "Required",
+                        text: $nightscoutURLFieldText, onCommit:
+                            {
+                                self.save()
+                            })
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)}
+                VStack{
+                    Text("API Secret")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    TextField(
+                        "Required",
+                        text: $apiSecretFieldText
+                    ) {
+                        self.save()
+                    }
+                    .autocapitalization(.none)
+                    .disableAutocorrection(true)}
                 if qrURLFieldText == "" {
                     Button {
                         isShowingScanner = true
                     } label: {
                         Text("Scan QR")
                     }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
                 } else {
                     TextField(
                         "QR Scan",


### PR DESCRIPTION
From user feedback (Loop and Learn Open Mic), indicated it was hard to know what fields were required in this view. 
 Updated onboarding view to note required fields w/ placeholder text.  Utilized VStacks so that each of the fields could display user inputted text on its own line.

Screenshot w/ changes:

![image](https://github.com/LoopKit/LoopCaregiver/assets/103870491/8771ac46-fefe-4972-9669-2c4548586cd6)

If there is a cleaner way to accomplish -- I'm open to any feedback.  Very new to SwiftUI components.

cc @gestrich 