### PR TITLE
Updated bottom bar carb icon to correct artwork

### DIFF
--- a/LoopCaregiver/LoopCaregiver/Views/Home/BottomBarView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Home/BottomBarView.swift
@@ -23,7 +23,7 @@ struct BottomBarView: View {
             Button {
                 showCarbView = true
             } label: {
-                Image("Pre-Meal")
+                Image("carbs")
                     .renderingMode(.template)
                     .foregroundColor(.green)
                     .frame(width: iconSize(), height: iconSize())


### PR DESCRIPTION
Updated bottom bar carb icon to correct artwork -- was pre-meal icon.  Both icons are in the asset catalog and available for use.