### PR TITLE
Added convenience buttons to carb time entry

### DIFF
--- a/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
@@ -104,10 +104,28 @@ struct CarbInputView: View {
             }
             
             LabeledContent {
-                Button {
-                    showDatePickerSheet = true
-                } label: {
-                    Text(dateFormatter.string(from: pickerConsumedDate))
+                HStack {
+                    Button {} label: {
+                        Image(systemName: "minus.circle.fill")
+                            .foregroundColor(Color.blue)
+                            .font(.title)
+                    }
+                    .onTapGesture {
+                        pickerConsumedDate -= 15 * 60
+                    }
+                    Button {
+                        showDatePickerSheet = true
+                    } label: {
+                        Text(Date.FormatStyle.FormatInput(rawValue: dateFormatter.string(from: pickerConsumedDate)) ?? pickerConsumedDate, format: Date.FormatStyle().hour().minute())
+                    }
+                    Button {} label: {
+                        Image(systemName: "plus.circle.fill")
+                            .foregroundColor(Color.blue)
+                            .font(.title)
+                    }
+                    .onTapGesture {
+                        pickerConsumedDate += 15 * 60
+                    }
                 }
             } label: {
                 Text("Time")


### PR DESCRIPTION
Added `-` and `+` buttons to carb entry view that decrements/increments the entry time by 15min.   Also updated the date format to be more aligned with Loop and only shows hh:mm (allows more space for some form factors such as iPhSE)

![image](https://github.com/LoopKit/LoopCaregiver/assets/103870491/535e2612-cee1-465f-9db0-762032061233)

cc @gestrich 

