### PR TITLE
iOS Widget Support

### DIFF
--- a/.github/workflows/build_loopcaregiver.yml
+++ b/.github/workflows/build_loopcaregiver.yml
@@ -30,7 +30,7 @@ jobs:
       
       # Build signed LoopCaregiver IPA file
       - name: Fastlane Build & Archive
-        run: fastlane caregiver_build
+        run: .github/workflows/workflows.sh build
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -38,6 +38,7 @@ jobs:
           FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
           FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
       
       # Upload to TestFlight
       - name: Fastlane upload to TestFlight

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -28,7 +28,7 @@ jobs:
       
       # Create or update certificate for LoopCaregiver
       - name: Create Caregiver Certificate
-        run: fastlane caregiver_cert
+        run: .github/workflows/workflows.sh create_certs
         env:
           TEAMID: ${{ secrets.TEAMID }}
           GH_PAT: ${{ secrets.GH_PAT }}
@@ -36,3 +36,4 @@ jobs:
           FASTLANE_KEY_ID: ${{ secrets.FASTLANE_KEY_ID }}
           FASTLANE_ISSUER_ID: ${{ secrets.FASTLANE_ISSUER_ID }}
           FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/workflows.sh
+++ b/.github/workflows/workflows.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+set -eu
+set -o errexit
+set -o pipefail
+set -o nounset
+
+## Workflows
+
+# Unused except for local testing.
+function create_identifier() {
+    if ! fastlane caregiver_identifier 2>1 | tee fastlane.log; then
+        echo "::error::Could not create identifiers. See error log for details."
+        exit 1
+    fi
+}
+
+# Unused except for local testing.
+function validate_secrets() {
+    if ! fastlane validate_secrets 2>1 | tee fastlane.log; then
+        echo "::error::Could not validate secrets. See error log for details."
+        exit 1
+    fi
+}
+
+function create_certs() {
+    
+    if ! fastlane caregiver_cert 2>1 | tee fastlane.log; then
+        while read -r line; do
+            if [[ "$line" == *"Error cloning certificates repo, please make sure you have read access to the repository you want to use"* ]]; then
+                # There may be a race condition between creating the repo and immediately cloning it.
+                # Note the Validate / Access job may catch this first.
+                readMeSectionTitle="Match-Secrets Repository Clone Issue"
+                errorMessage="There was an error cloning the Match-Secrets repository. First try running the `Create Certificates` step again. If that fails, check your Github repository access."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"Authentication credentials are missing or invalid."* ]]; then
+                # Ex: Authentication credentials are missing or invalid. - Provide a properly configured and signed bearer token, and make sure that it has not expired. Learn more about Generating Tokens for API Requests https://developer.apple.com/go/?id=api-generating-tokens
+                readMeSectionTitle="Credentials Invalid"
+                errorMessage="There was an error with your credentials. First try running the `Create Certificates` step again. If that fails, check the following secrets FASTLANE_ISSUER_ID, FASTLANE_KEY_ID, FASTLANE_KEY, and GH_PAT."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"Certificate "* && "$line" == *"(stored in your storage) is not available on the Developer Portal"* ]]; then
+                #Ex: Certificate 'WZUK5NWX3L' (stored in your storage) is not available on the Developer Portal
+                logMissingCertificateError "$1"
+                exit 1
+            elif [[ "$line" == *"Could not create another Distribution certificate, reached the maximum number of available Distribution certificates."* ]]; then
+                #Occurs if you exceed certs. This can happen if you keep add/delete the Match-Secrets repo during testing.
+                readMeSectionTitle="Maximum Certificates Reached"
+                errorMessage="Cannot create a new certificate. Login to the Apple developer portal and delete unneeded certificates."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"Couldn't find bundle identifier"* && "$line" =~ identifier\ \'([^\']+)\' ]]; then
+                #Ex: Couldn't find bundle identifier 'com.5K844XFC6W.loopkit.LoopCaregiver.LoopCaregiverIntentExtension' for the user ''
+                captured_id="${BASH_REMATCH[1]}"
+                readMeSectionTitle="Missing Bundle Identifier"
+                errorMessage="The app identifier '${captured_id}' is missing from the Apple Developer portal. Resolve this by re-running the 'Add Identifiers' and 'Create Certificates' workflows."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            fi
+        done <fastlane.log
+        
+        #Default
+        echo "::error::Could not create certificates. See error log for details."
+        exit 1
+    fi
+}
+
+function build() {
+    if ! fastlane caregiver_build 2>1 | tee fastlane.log; then
+        while read -r line; do
+            if [[ "$line" == *"Error cloning certificates git repo"* ]]; then
+                # Ex: Error cloning certificates git repo, please make sure you have access to the repository - see instructions above
+                # Occurs after deleting the match repo. The Validate Secrets step will recreate it.
+                # Note the Validate / Access job may catch this first.
+                readMeSectionTitle="Match Repository Missing"
+                errorMessage="The Match-Secrets repository is missing. To resolve, run the 'Validate Secrets' step again."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"Certificate "* && "$line" == *"(stored in your storage) is not available on the Developer Portal"* ]]; then
+                #Ex: Certificate 'WZUK5NWX3L' (stored in your storage) is not available on the Developer Portal
+                logMissingCertificateError "$1"
+                exit 1
+            #TODO: I have not seen this one for a while - delete this case if I can't reproduce after trying an upgrade.
+            elif [[ "$line" == *"No matching provisioning profiles found for"* ]]; then
+                readMeSectionTitle="Provisioning Profiles Invalid"
+                errorMessage="Provisioning profile(s) are invalid. Run the the 'Add Identifiers' and 'Create Certificates' workflows."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"doesn't support the App Groups capability"*  && "$line" =~ \(in\ target\ \'([^\']+)\' ]]; then
+                #Replicate this error by removing the App Group capability from the identifier
+                app_identifier="${BASH_REMATCH[1]}"
+                readMeSectionTitle="App Group Capability Missing"
+                errorMessage="Resolve this by logging into the Apple Developer portal and add the '$(appGroupName)' app group (where *** is your 10-character TEAMID) to the '${app_identifier}' identifier. Then re-run the 'Create Certificates' and 'Build Caregiver' workflows."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"doesn't match the entitlements file's value for the com.apple.security.application-groups entitlement"* && "$line" =~ \(in\ target\ \'([^\']+)\' ]]; then
+                app_identifier="${BASH_REMATCH[1]}"
+                #Missing or wrong App Group but the group capablity is added.
+                #Ex: error: Provisioning profile "match AppStore com.5K844XFC6W.loopkit.LoopCaregiver.LoopCaregiverWidgetExtension" doesn't match the entitlements file's value for the com.apple.security.application-groups entitlement. (in target 'LoopCaregiverWidgetExtension' from project 'LoopCaregiver')[0m
+                readMeSectionTitle="Bundle Identifier Missing App Group"
+                errorMessage="A bundle identifier is missing the required app group. Resolve this by logging into the Apple Developer portal and add the '$(appGroupName)' app group (where *** is your 10-character TEAMID) to the '${app_identifier}' identifier. Add this app group to the app identifiers. Then re-run the 'Create Certificates' and 'Build Caregiver' workflows."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            elif [[ "$line" == *"doesn't include signing certificate "* && "$line" =~ \(in\ target\ \'([^\']+)\' ]]; then
+                #This can happen if you delete the Match repo and skip the `Create Certificates` step.
+                #Ex: error: Provisioning profile "match AppStore com.5K844XFC6W.loopkit.LoopCaregiver.LoopCaregiverWatchApp" doesn't include signing certificate "Apple Distribution: William Gestrich (5K844XFC6W)". (in target 'LoopCaregiverWatchApp' from project 'LoopCaregiver')
+                app_identifier="${BASH_REMATCH[1]}"
+                readMeSectionTitle="Missing Signing Certificates"
+                errorMessage="The provisioning profile for $app_identifier is missing its signing certificate. To resolve, run the 'Create Certificates' workflow again."
+                logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+                exit 1
+            fi
+        done <fastlane.log
+        
+        #Default
+        echo "::error::Could not build Loop Caregiver. See error log for details."
+        exit 1
+    fi
+}
+
+# Unused except for local testing.
+function release() {
+    if ! fastlane caregiver_release 2>1 | tee fastlane.log; then
+        #Default
+        echo "::error::Could not create release. See error log for details."
+        exit 1
+    fi
+}
+
+## Environment Helpers
+
+function appGroupName() {
+    echo "group.com.$TEAMID.loopkit.LoopCaregiverGroup"
+}
+
+## Error Message Helpers
+
+function logMissingCertificateError() {
+    #Occurs after deleting your certificate. No steps seem to fix this, except deleting the Match-Secrets repo.
+    line="$1"
+    readMeSectionTitle="Certificate is Missing"
+    errorMessage="Certificate is missing from the Apple developer portal. Resolve this by deleting the Github Match-Secrets repository. Then run all Gihub workflows again."
+    logErrorMessages "${readMeSectionTitle}" "${errorMessage}" "${line}"
+}
+
+function logErrorMessages() {
+    readMeSectionTitle="$1"
+    errorMessage="$2"
+    rawError="$3"
+    readMeID="$(echo $readMeSectionTitle | tr " " "-")"
+    branchName=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+    readMEURL="${REPO_URL}/blob/${branchName}/fastlane/testflight.md"
+    echo "::error title=$readMeSectionTitle::$errorMessage For more details on this error: ${readMEURL}/#${readMeID}"
+    echo "::error title=Fastlane Details::$rawError"
+}
+
+## Invoke any script function from the command line
+
+if [ $# -gt 0 ]; then
+  "$@"
+else
+  # Show a helpful error
+  echo "Functions Available:"
+  typeset -f | awk '!/^main[ (]/ && /^[^ {}]+ *\(\)/ { gsub(/[()]/, "", $1); print $1}'
+  exit 1
+fi

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		A9CFDD202AEBFF1200FA701B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CFDD1F2AEBFF1200FA701B /* ContentView.swift */; };
 		A9CFDD222AEBFF1400FA701B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9CFDD212AEBFF1400FA701B /* Assets.xcassets */; };
 		A9CFDD252AEBFF1400FA701B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A9CFDD242AEBFF1400FA701B /* Preview Assets.xcassets */; };
+		A9CFDD292AEBFF1400FA701B /* LoopCaregiverWatchApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = A9CFDD1B2AEBFF1200FA701B /* LoopCaregiverWatchApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A9CFDD322AEC02D600FA701B /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A99F2F372A29350C00F7DE2D /* WidgetKit.framework */; };
 		A9CFDD332AEC02D600FA701B /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A99F2F392A29350D00F7DE2D /* SwiftUI.framework */; };
 		A9CFDD362AEC02D600FA701B /* LoopCaregiverWatchAppExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9CFDD352AEC02D600FA701B /* LoopCaregiverWatchAppExtension.swift */; };
@@ -173,6 +174,7 @@
 		A9D2B8272A2CAFD500826490 /* LocalizationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = A97B729B293E83BA0053DBB8 /* LocalizationUtils.swift */; };
 		A9D3FF222A6C3B99000C891D /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D3FF212A6C3B99000C891D /* Color.swift */; };
 		A9D3FF242A6C3C54000C891D /* HKUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9D3FF232A6C3C54000C891D /* HKUnit.swift */; };
+		A9E14D3A2A2BA5A600BDB93D /* LoopCaregiverWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A99F2F362A29350C00F7DE2D /* LoopCaregiverWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A9E14D3F2A2BB18500BDB93D /* LatestGlucoseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E14D3E2A2BB18500BDB93D /* LatestGlucoseView.swift */; };
 		A9EC197C291FEF940022D39F /* LoopCaregiverApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC197B291FEF940022D39F /* LoopCaregiverApp.swift */; };
 		A9EC197E291FEF940022D39F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC197D291FEF940022D39F /* ContentView.swift */; };
@@ -196,6 +198,7 @@
 		A9EFD0042AE093F9008D63EC /* DeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFCFFF2ADF6A01008D63EC /* DeepLinkParser.swift */; };
 		A9F871202A2EBE63007EC235 /* Intents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9F8711F2A2EBE63007EC235 /* Intents.framework */; };
 		A9F871232A2EBE63007EC235 /* IntentHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F871222A2EBE63007EC235 /* IntentHandler.swift */; };
+		A9F871382A2EBE64007EC235 /* LoopCaregiverIntentExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = A9F8711E2A2EBE63007EC235 /* LoopCaregiverIntentExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A9F8713F2A2EBE79007EC235 /* LoopCaregiverWidget.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = A99F2F422A29350D00F7DE2D /* LoopCaregiverWidget.intentdefinition */; };
 		A9F871402A2FF2F5007EC235 /* CoreDataAccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9972773292FC0B0006C8C74 /* CoreDataAccountService.swift */; };
 		A9F871412A2FF2F5007EC235 /* AccountService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96929902927FFBA00B8BF43 /* AccountService.swift */; };
@@ -238,12 +241,33 @@
 			remoteGlobalIDString = A9EC1977291FEF940022D39F;
 			remoteInfo = LoopCaregiver;
 		};
+		A9CFDD262AEBFF1400FA701B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9EC1970291FEF940022D39F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A9CFDD1A2AEBFF1200FA701B;
+			remoteInfo = "LoopCaregiverWatchApp Watch App";
+		};
 		A9CFDD3C2AEC02D700FA701B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A9EC1970291FEF940022D39F /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = A9CFDD302AEC02D600FA701B;
 			remoteInfo = LoopCaregiverWatchAppExtensionExtension;
+		};
+		A9E14D382A2BA59C00BDB93D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9EC1970291FEF940022D39F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A99F2F352A29350C00F7DE2D;
+			remoteInfo = LoopCaregiverWidgetExtension;
+		};
+		A9F871362A2EBE64007EC235 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A9EC1970291FEF940022D39F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A9F8711D2A2EBE63007EC235;
+			remoteInfo = MyIntentExtension;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -261,6 +285,17 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A9CFDD282AEBFF1400FA701B /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				A9CFDD292AEBFF1400FA701B /* LoopCaregiverWatchApp.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A9CFDD422AEC02D700FA701B /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -268,6 +303,18 @@
 			dstSubfolderSpec = 13;
 			files = (
 				A9CFDD3E2AEC02D700FA701B /* LoopCaregiverWatchAppExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A9E14D3D2A2BA5A600BDB93D /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				A9F871382A2EBE64007EC235 /* LoopCaregiverIntentExtension.appex in Embed Foundation Extensions */,
+				A9E14D3A2A2BA5A600BDB93D /* LoopCaregiverWidgetExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -956,10 +1003,15 @@
 				A9EC1975291FEF940022D39F /* Frameworks */,
 				A9EC1976291FEF940022D39F /* Resources */,
 				A95F50C2292A602F00079AAF /* Embed Frameworks */,
+				A9E14D3D2A2BA5A600BDB93D /* Embed Foundation Extensions */,
+				A9CFDD282AEBFF1400FA701B /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				A9E14D392A2BA59C00BDB93D /* PBXTargetDependency */,
+				A9F871372A2EBE64007EC235 /* PBXTargetDependency */,
+				A9CFDD272AEBFF1400FA701B /* PBXTargetDependency */,
 			);
 			name = LoopCaregiver;
 			packageProductDependencies = (
@@ -1350,10 +1402,25 @@
 			target = A9EC1977291FEF940022D39F /* LoopCaregiver */;
 			targetProxy = A9346F872AC9820500C15F70 /* PBXContainerItemProxy */;
 		};
+		A9CFDD272AEBFF1400FA701B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A9CFDD1A2AEBFF1200FA701B /* LoopCaregiverWatchApp */;
+			targetProxy = A9CFDD262AEBFF1400FA701B /* PBXContainerItemProxy */;
+		};
 		A9CFDD3D2AEC02D700FA701B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A9CFDD302AEC02D600FA701B /* LoopCaregiverWatchAppExtension */;
 			targetProxy = A9CFDD3C2AEC02D700FA701B /* PBXContainerItemProxy */;
+		};
+		A9E14D392A2BA59C00BDB93D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A99F2F352A29350C00F7DE2D /* LoopCaregiverWidgetExtension */;
+			targetProxy = A9E14D382A2BA59C00BDB93D /* PBXContainerItemProxy */;
+		};
+		A9F871372A2EBE64007EC235 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A9F8711D2A2EBE63007EC235 /* LoopCaregiverIntentExtension */;
+			targetProxy = A9F871362A2EBE64007EC235 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/LoopCaregiver/LoopCaregiver/LoopCaregiver.entitlements
+++ b/LoopCaregiver/LoopCaregiver/LoopCaregiver.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
+	</array>
+</dict>
 </plist>

--- a/LoopCaregiver/LoopCaregiverIntentExtension/LoopCaregiverIntentExtension.entitlements
+++ b/LoopCaregiver/LoopCaregiverIntentExtension/LoopCaregiverIntentExtension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
+	</array>
+</dict>
 </plist>

--- a/LoopCaregiver/LoopCaregiverWatchApp/LoopCaregiverWatchApp.entitlements
+++ b/LoopCaregiver/LoopCaregiverWatchApp/LoopCaregiverWatchApp.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+	  <string>$(APP_GROUP_IDENTIFIER)</string>
+	</array>
+</dict>
 </plist>

--- a/LoopCaregiver/LoopCaregiverWatchAppExtension/LoopCaregiverWatchAppExtension.entitlements
+++ b/LoopCaregiver/LoopCaregiverWatchAppExtension/LoopCaregiverWatchAppExtension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+	  <string>$(APP_GROUP_IDENTIFIER)</string>
+	</array>
+</dict>
 </plist>

--- a/LoopCaregiver/LoopCaregiverWidgetExtension/LoopCaregiverWidgetExtension.entitlements
+++ b/LoopCaregiver/LoopCaregiverWidgetExtension/LoopCaregiverWidgetExtension.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>$(APP_GROUP_IDENTIFIER)</string>
+	</array>
+</dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Clone Repo
 
-* Xcode version 14 or greater required
+* Xcode version 15 or greater required
 * Run the following command to clone the repo to a new directory named "LoopCaregiver" (The directory will be created for you)
 ```
 git clone --branch=dev --recurse-submodules https://github.com/LoopKit/LoopCaregiver LoopCaregiver

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,6 +56,10 @@ platform :ios do
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
       app_identifier: [
         "com.#{TEAMID}.loopkit.LoopCaregiver",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.IntentExtension",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.WidgetExtension",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp.WidgetExtension",
       ]
     )
 
@@ -80,6 +84,34 @@ platform :ios do
       profile_name: mapping["com.#{TEAMID}.loopkit.LoopCaregiver"],
       code_sign_identity: "iPhone Distribution",
       targets: ["LoopCaregiver"]
+    )
+
+    update_code_signing_settings(
+      path: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      profile_name: mapping["com.#{TEAMID}.loopkit.LoopCaregiver.IntentExtension"],
+      code_sign_identity: "iPhone Distribution",
+      targets: ["LoopCaregiverIntentExtension"]
+    )
+
+    update_code_signing_settings(
+      path: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      profile_name: mapping["com.#{TEAMID}.loopkit.LoopCaregiver.WidgetExtension"],
+      code_sign_identity: "iPhone Distribution",
+      targets: ["LoopCaregiverWidgetExtension"]
+    )
+
+    update_code_signing_settings(
+      path: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      profile_name: mapping["com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp"],
+      code_sign_identity: "iPhone Distribution",
+      targets: ["LoopCaregiverWatchApp"]
+    )
+
+    update_code_signing_settings(
+      path: "#{GITHUB_WORKSPACE}/LoopCaregiver/LoopCaregiver.xcodeproj",
+      profile_name: mapping["com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp.WidgetExtension"],
+      code_sign_identity: "iPhone Distribution",
+      targets: ["LoopCaregiverWatchAppExtension"]
     )
 
     gym(
@@ -132,6 +164,23 @@ platform :ios do
     end
 
     configure_bundle_id("LoopCaregiver", "com.#{TEAMID}.loopkit.LoopCaregiver", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
+    ])
+
+    configure_bundle_id("LoopCaregiverIntentExtension", "com.#{TEAMID}.loopkit.LoopCaregiver.IntentExtension", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
+    ])
+
+    configure_bundle_id("LoopCaregiverWidgetExtension", "com.#{TEAMID}.loopkit.LoopCaregiver.WidgetExtension", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
+    ])
+
+    configure_bundle_id("LoopCaregiverWatch", "com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
+    ])
+
+    configure_bundle_id("LoopCaregiverWatchWidgetExtension", "com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp.WidgetExtension", [
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
     ])
 
   end
@@ -146,13 +195,17 @@ platform :ios do
       issuer_id: "#{FASTLANE_ISSUER_ID}",
       key_content: "#{FASTLANE_KEY}"
     )
-    
+
     match(
       type: "appstore",
       force: true,
       git_basic_authorization: Base64.strict_encode64("#{GITHUB_REPOSITORY_OWNER}:#{GH_PAT}"),
       app_identifier: [
         "com.#{TEAMID}.loopkit.LoopCaregiver",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.IntentExtension",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.WidgetExtension",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp",
+        "com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp.WidgetExtension",
       ]
     )
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -184,6 +184,18 @@ platform :ios do
     ])
 
   end
+  
+  class CaregiverBuildError < StandardError; end
+  
+  def createCaregiverError(error_message)
+      return CaregiverBuildError.new("Error: #{error_message}")
+  end
+
+  class CaregiverBuildError < StandardError; end
+
+  def createCaregiverError(error_message)
+      return CaregiverBuildError.new("Error: #{error_message}")
+  end
 
   desc "Provision Caregiver Certificate"
   lane :caregiver_cert do
@@ -196,6 +208,34 @@ platform :ios do
       key_content: "#{FASTLANE_KEY}"
     )
 
+    def validate_bundle_id(identifier)
+
+      bundle_id = Spaceship::ConnectAPI::BundleId.find(identifier)
+
+      # Throw an error if the bundle_id can't be found
+      raise createCaregiverError("App Identifier not found for: #{identifier}") if bundle_id.nil?
+
+      capabilities = bundle_id.get_capabilities
+
+      # Try to find a capability where capability_type is "APP_GROUPS"
+      app_group_capability_exists = false
+      capabilities.each do |capability|
+        if capability.capability_type == "APP_GROUPS"
+          app_group_capability_exists = true
+          break
+        end
+      end
+
+      # Throw an error if no such capability exists
+      raise createCaregiverError("APP_GROUPS capability not found for identifier: #{identifier}") unless app_group_capability_exists
+    end
+
+    #validate_bundle_id("com.#{TEAMID}.loopkit.LoopCaregiver")
+    #validate_bundle_id("com.#{TEAMID}.loopkit.LoopCaregiver.IntentExtension")
+    #validate_bundle_id("com.#{TEAMID}.loopkit.LoopCaregiver.WidgetExtension")
+    #validate_bundle_id("com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp")
+    #validate_bundle_id("com.#{TEAMID}.loopkit.LoopCaregiver.watchkitapp.WidgetExtension")
+    
     match(
       type: "appstore",
       force: true,

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -91,12 +91,45 @@ This step validates most of your six Secrets and provides error messages if it d
 1. On the right side, click "Run Workflow", and tap the green `Run workflow` button.
 1. Wait, and within a minute or two you should see a green checkmark indicating the workflow succeeded.
 
+## Create App Group
+
+If you have already built LoopCaregiver via Xcode using this Apple ID, you can skip on to [Add App Group to Bundle Identifiers](#add-app-group-to-bundle-identifiers).
+
+1. Go to [Register an App Group](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/) on the apple developer site.
+1. For Description, use "LoopCargiver App Group".
+1. For Identifier, enter "group.com.TEAMID.loopkit.LoopCaregiverGroup", subsituting your team id for `TEAMID`.
+1. Click "Continue" and then "Register".
+
+## Add App Group to Bundle Identifiers
+
+Note 1 - If you previously built with Xcode, the `Names` listed below may be different, but the `Identifiers` will match. A table is provided below the steps to assist. The Add Identifier Action that you completed above generates these 5 identifiers.
+
+Note 2 - Depending on your build history, you may find some of the Identifiers are already configured - and you are just verifying the status; but in other cases, you will need to configure the Identifiers.
+
+1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) on the apple developer site.
+1. For each of the following identifier names: 
+    * LoopCaregiver
+    * LoopCaregiverWidgetExtension
+    * LoopCaregiverIntentExtension
+    * LoopCaregiverWatch
+    * LoopCaregiverWatchWidgetExtension
+1. Click on the identifier's name.
+1. On the "App Groups" capabilies, click on the "Configure" button.
+1. Select the "LoopCaregiver App Group"
+1. Click "Continue".
+1. Click "Save".
+1. Click "Confirm".
+1. Remember to do this for each of the identifiers above.
+
 #### Table with Name and Identifiers for LoopCaregiver
 
 | NAME | IDENTIFIER |
 |-------|------------|
 | LoopCaregiver | com.TEAMID.loopkit.LoopCaregiver |
-
+| LoopCaregiverWidgetExtension | com.TEAMID.loopkit.LoopCaregiver.WidgetExtension |
+| LoopCaregiverIntentExtension | com.TEAMID.loopkit.LoopCaregiver.IntentExtension |
+| LoopCaregiverWatch | com.TEAMID.loopkit.LoopCaregiver.watchkitapp |
+| LoopCaregiverWatchWidgetExtension | com.TEAMID.loopkit.LoopCaregiver.watchkitapp.WidgetExtension |
 
 ## Create LoopCaregiver App in App Store Connect
 
@@ -134,3 +167,106 @@ You do not need to fill out the next form. That is for submitting to the app sto
 ## TestFlight and Deployment Details
 
 Please refer to [LoopDocs: Set Up Users](https://loopkit.github.io/loopdocs/gh-actions/gh-first-time/#set-up-users-and-access-testflight) and [LoopDocs: Deploy](https://loopkit.github.io/loopdocs/gh-actions/gh-deploy/)
+
+## App Group Update
+
+The Caregiver app was updated in November 2023 to require App Groups for iOS widget support. You need to take some extra steps the first time you build since the update. Select each link and follow the steps to complete the update.
+
+1. [Add Identifiers for LoopCaregiver App](#add-identifiers-for-loopcaregiver-app)
+1. [Create App Group](#create-app-group)
+1. [Add App Group to Bundle Identifiers](#add-app-group-to-bundle-identifiers)
+1. [Create Building Certificates](#create-building-certificates)
+1. [Build LoopCaregiver](#build-loopcaregiver)
+
+## Build Errors
+
+### App Group Capability Missing
+
+This error means the app identifiers in the Apple Developer portal are missing the app group capability. To resolve:
+
+1. Perform the [App Group Update](#app-group-update) steps.
+1. Pay close attention to the "Add App Group to Bundle Identifiers" as this error suggests at least one of your app identifiers is missing the LoopCaregiver App Group.
+
+### Match Repository Missing
+
+This error indicates the Match-Secrets repository is missing or was deleted. To resolve: 
+
+1. [Validate repository secrets](#validate-repository-secrets). This will create the Match-Secrets repository.
+1. [Add Identifiers for LoopCaregiver App](#add-identifiers-for-loopcaregiver-app)
+1. [Create Building Certificates](#create-building-certificates)
+1. [Build LoopCaregiver](#build-loopcaregiver)
+
+### Credentials Invalid
+
+This is often a temporary issue that can be resolved by:
+
+* Run [Create Building Certificates](#create-building-certificates) again.
+
+If that fails, there is likely an issue with one of your saved secrets. Check that you set the following secrets correctly. See [Setup GitHub LoopCaregiver Repository](#Setup-GitHub-LoopCaregiver-Repository).
+
+* FASTLANE_ISSUER_ID
+* FASTLANE_KEY_ID
+* FASTLANE_KEY
+* GH_PAT
+
+### Match-Secrets Repository Clone Issue
+
+This is often a temporary issue that can be resolved by:
+
+* Run [Create Building Certificates](#create-building-certificates) again.
+
+If that fails, there is likely an issue with one of your saved secrets. Try these steps:
+
+1. Check your Github Personal Access Token has the correct permissions. See [Create GitHub Personal Access Token](create-github-personal-access-token)
+1. Check that the Github Personal Access Token (GH_PAT) was stored as a secret. See the secret setup steps in [Setup GitHub LoopCaregiver Repository](setup-gitHub-loopcaregiver-repository)
+
+### Missing Bundle Identifier
+
+This error indicates you are missing some required bundle identifier(s).
+
+In November 2023, existing Caregiver builds require a 1 time update. Perform the [App Group Update](#app-group-update) steps if not completed yet.
+
+If those steps were already completed, instead try the following:
+
+1. [Add Identifiers for LoopCaregiver App](#add-identifiers-for-loopcaregiver-app)
+1. [Create Building Certificates](#create-building-certificates)
+
+### Bundle Identifier Missing App Group
+
+This error indicates one or more of your App Identifiers are not assigned the "LoopCaregiver App Group". To resolve:
+
+1. Create the Caregiver app group if not previously done. Follow the steps [Create App Group](#create-app-group).
+1. Add the app group for each bundle identifier. Follow the steps in [Add App Group to Bundle Identifiers](#Add-App-Group-to-Bundle-Identifiers)
+1. [Create Building Certificates](#create-building-certificates)
+1. [Build LoopCaregiver](#build-loopcaregiver)
+
+### Certificate is Missing
+
+This error indicates your Apple Certificate is missing. To resolve:
+
+1. Delete the Github Match-Secrets repository.
+1. [Validate repository secrets](#validate-repository-secrets). This will create the Match-Secrets repository.
+1. [Add Identifiers for LoopCaregiver App](#add-identifiers-for-loopcaregiver-app)
+1. [Create Building Certificates](#create-building-certificates)
+1. [Build LoopCaregiver](#build-loopcaregiver)
+
+### Maximum Certificates Reached
+
+This error indicates you have too many certificates on the Apple developer portal. This sometimes occurs after deleting and recreating your Match Secrets repository. To resolve:
+
+1. Login to the Apple developer portal. 
+1. Go to the "Certificates" page. 
+1. Delete all "Distribution" certificates that contain "API Key" in the "Created By" column.
+
+### Provisioning Profiles Invalid
+
+This error indicates a provisioning profile(s) is invalid. To resolve:
+
+1. [Add Identifiers for LoopCaregiver App](#add-identifiers-for-loopcaregiver-app)
+1. [Create Building Certificates](#create-building-certificates)
+
+### Missing Signing Certificates
+
+The error indicates a provisioning profile is missing its signing certificate. To resolve: 
+
+* [Create Building Certificates](#create-building-certificates)


### PR DESCRIPTION
This PR will add support for iOS widgets. Attached is the [guide](https://docs.google.com/document/d/1Np4jusdXZERiAWZsz6QyF3b1FxT_ingJEw7R97632Hk/edit#heading=h.jn3e5xg75sf) I've been sharing.

Widget Support

* Add new app identifiers for widget and future watch support.
* Add App Group - needed to share data between widget and app. Existing Caregiver data is migrated as part of this (no data loss should occur)
* Add Watch app & Watch widget for future work. These are not functional yet but this seems like the right time to do this to avoid another build migration.

Github Action Updates

* Add Github annotations for errors. Include link in annotation to relevant readme section.
* Bash script to support more complex Github error annotations & running scripts locally. This is only being used for the "Create Certificates" and "Build Caregiver" workflows at the moment. I did not change the handling of the other workflows in Caregiver.
