### PR TITLE
Sync the GitHub runner clock with the Windows time server

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -25,6 +25,10 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
         
       # Create or update identifier for LoopCaregiver
       - name: Fastlane Provision Caregiver

--- a/.github/workflows/build_loopcaregiver.yml
+++ b/.github/workflows/build_loopcaregiver.yml
@@ -27,6 +27,10 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
       
       # Build signed LoopCaregiver IPA file
       - name: Fastlane Build & Archive

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -25,7 +25,11 @@ jobs:
       # Patch Fastlane Match to not print tables
       - name: Patch Match Tables
         run: find /usr/local/lib/ruby/gems -name table_printer.rb | xargs sed -i "" "/puts(Terminal::Table.new(params))/d"
-      
+
+      # Sync the GitHub runner clock with the Windows time server (workaround as suggested in https://github.com/actions/runner/issues/2996)
+      - name: Sync clock
+        run: sudo sntp -sS time.windows.com
+        
       # Create or update certificate for LoopCaregiver
       - name: Create Caregiver Certificate
         run: fastlane caregiver_cert


### PR DESCRIPTION
Adding a step to workflow jobs that interface Apple servers, as a workaround for build issues caused by runner clocks being out of sync. See https://github.com/actions/runner issue number 2996 for details.

name: Sync clock
run: sudo sntp -sS time.windows.com
Added to the following workflows / jobs:

add_identifiers.yml / identifiers
build_loopcaregiver.yml / build
create_certs.yml / certificates
