### PR TITLE
Add expire report and alert

### DIFF
--- a/LoopCaregiver/BuildDetails.plist
+++ b/LoopCaregiver/BuildDetails.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   BuildDetails.plist
+   Loop
+
+   Created by Pete Schwamb on 6/13/23.
+   Copyright (c) 2023 LoopKit Authors. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -191,6 +191,9 @@
 		A9EC5C7E2B10E9FC00AA32EF /* UserDefaults+Watch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC5C7D2B10E9FC00AA32EF /* UserDefaults+Watch.swift */; };
 		A9EC5C7F2B10E9FC00AA32EF /* UserDefaults+Watch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EC5C7D2B10E9FC00AA32EF /* UserDefaults+Watch.swift */; };
 		A9EC5C802B10EA9100AA32EF /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99F2F512A2A92D100F7DE2D /* Bundle+Extensions.swift */; };
+		A9ECCB282B286CD90057DEDF /* AppExpirationAlerter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ECCB272B286CD90057DEDF /* AppExpirationAlerter.swift */; };
+		A9ECCB2A2B286DB50057DEDF /* UserDefaults+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ECCB292B286DB50057DEDF /* UserDefaults+Extensions.swift */; };
+		A9ECCB2C2B29C5270057DEDF /* AppExpirationAlerterRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ECCB2B2B29C5270057DEDF /* AppExpirationAlerterRepresentable.swift */; };
 		A9EEB92B29D4FCB3004EE7FB /* NightscoutKit in Frameworks */ = {isa = PBXBuildFile; productRef = A9EEB92A29D4FCB3004EE7FB /* NightscoutKit */; };
 		A9EFD0002ADF6A01008D63EC /* DeepLinkParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFCFFF2ADF6A01008D63EC /* DeepLinkParser.swift */; };
 		A9EFD0022AE08418008D63EC /* DeepLinkParserTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EFD0012AE08418008D63EC /* DeepLinkParserTestCase.swift */; };
@@ -452,6 +455,9 @@
 		A9EC19AA292156D80022D39F /* CarbInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbInputView.swift; sourceTree = "<group>"; };
 		A9EC19AC2921A19C0022D39F /* BolusInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BolusInputView.swift; sourceTree = "<group>"; };
 		A9EC5C7D2B10E9FC00AA32EF /* UserDefaults+Watch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Watch.swift"; sourceTree = "<group>"; };
+		A9ECCB272B286CD90057DEDF /* AppExpirationAlerter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExpirationAlerter.swift; sourceTree = "<group>"; };
+		A9ECCB292B286DB50057DEDF /* UserDefaults+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extensions.swift"; sourceTree = "<group>"; };
+		A9ECCB2B2B29C5270057DEDF /* AppExpirationAlerterRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExpirationAlerterRepresentable.swift; sourceTree = "<group>"; };
 		A9EFCFFF2ADF6A01008D63EC /* DeepLinkParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkParser.swift; sourceTree = "<group>"; };
 		A9EFD0012AE08418008D63EC /* DeepLinkParserTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkParserTestCase.swift; sourceTree = "<group>"; };
 		A9F8711E2A2EBE63007EC235 /* LoopCaregiverIntentExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = LoopCaregiverIntentExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -684,6 +690,7 @@
 				A969293D2926EFEC00B8BF43 /* AccountServiceManager.swift */,
 				B63A43D62B2549BA004CFEAA /* BuildDetails.swift */,
 				A99F2F512A2A92D100F7DE2D /* Bundle+Extensions.swift */,
+				A9ECCB292B286DB50057DEDF /* UserDefaults+Extensions.swift */,
 				A90DB9532930F879004B58D3 /* CaregiverSettings.swift */,
 				A9972773292FC0B0006C8C74 /* CoreDataAccountService.swift */,
 				A9EFCFFF2ADF6A01008D63EC /* DeepLinkParser.swift */,
@@ -714,6 +721,7 @@
 			children = (
 				A969293E2926EFEC00B8BF43 /* LooperSetupView.swift */,
 				A9B033E729231DCE0052AA9E /* SettingsView.swift */,
+				A9ECCB272B286CD90057DEDF /* AppExpirationAlerter.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -725,6 +733,7 @@
 				A9EC197D291FEF940022D39F /* ContentView.swift */,
 				A99DC86429992DD20058EBA5 /* DisclaimerView.swift */,
 				A96929342926E5CE00B8BF43 /* HUDView.swift */,
+				A9ECCB2B2B29C5270057DEDF /* AppExpirationAlerterRepresentable.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1014,7 +1023,7 @@
 				A95F50C2292A602F00079AAF /* Embed Frameworks */,
 				A9E14D3D2A2BA5A600BDB93D /* Embed Foundation Extensions */,
 				A9CFDD282AEBFF1400FA701B /* Embed Watch Content */,
-				B63A43DC2B254B4E004CFEAA /* ShellScript */,
+				B63A43DC2B254B4E004CFEAA /* Capture Build Details */,
 			);
 			buildRules = (
 			);
@@ -1169,7 +1178,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		B63A43DC2B254B4E004CFEAA /* ShellScript */ = {
+		B63A43DC2B254B4E004CFEAA /* Capture Build Details */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1178,6 +1187,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Capture Build Details";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -1313,6 +1323,7 @@
 				A9A362DD2A80EEFE007B017C /* OverrideRemoteNotification.swift in Sources */,
 				A94702692932429F00FB3E59 /* DoseChartView.swift in Sources */,
 				A98D4CB2292C394800EFF5C6 /* NightscoutCredentials.swift in Sources */,
+				A9ECCB2A2B286DB50057DEDF /* UserDefaults+Extensions.swift in Sources */,
 				A95223792A7FA0890070FE13 /* RemoteCommand+Charts.swift in Sources */,
 				A9C4D7E62969A69F00D3875F /* IOBStatus.swift in Sources */,
 				A98348912AD206CD0034ABB2 /* PresetRowView.swift in Sources */,
@@ -1335,6 +1346,7 @@
 				A96929912927FFBA00B8BF43 /* AccountService.swift in Sources */,
 				A9EC19AB292156D80022D39F /* CarbInputView.swift in Sources */,
 				A9A45D702A77B5480013CD5B /* NoteNightscoutTreatment.swift in Sources */,
+				A9ECCB2C2B29C5270057DEDF /* AppExpirationAlerterRepresentable.swift in Sources */,
 				A9C4D7F22969B78A00D3875F /* BolusNightscoutTreatment.swift in Sources */,
 				A9B033E829231DCE0052AA9E /* SettingsView.swift in Sources */,
 				A95223662A7EDA9B0070FE13 /* OverrideAction.swift in Sources */,
@@ -1365,6 +1377,7 @@
 				A99DC86529992DD20058EBA5 /* DisclaimerView.swift in Sources */,
 				A9BD7B532AD0D8D300E73973 /* OverrideInsulinNeedsView.swift in Sources */,
 				A9972774292FC0B0006C8C74 /* CoreDataAccountService.swift in Sources */,
+				A9ECCB282B286CD90057DEDF /* AppExpirationAlerter.swift in Sources */,
 				A96929402926EFEC00B8BF43 /* AccountServiceManager.swift in Sources */,
 				A99F2F472A29350F00F7DE2D /* LoopCaregiverWidget.intentdefinition in Sources */,
 				A9C4D7E82969A6A900D3875F /* COBStatus.swift in Sources */,

--- a/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
+++ b/LoopCaregiver/LoopCaregiver.xcodeproj/project.pbxproj
@@ -231,6 +231,9 @@
 		A9FE41062ADC672900DD88E4 /* ServiceComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9299C422ADC3DE7009193AB /* ServiceComposer.swift */; };
 		A9FE41072ADC672900DD88E4 /* ServiceComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9299C422ADC3DE7009193AB /* ServiceComposer.swift */; };
 		A9FE41082ADC675900DD88E4 /* NSPersistentStoreCoordinator+Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A92AB6C52A3153DD00977536 /* NSPersistentStoreCoordinator+Migration.swift */; };
+		B63A43D72B2549BA004CFEAA /* BuildDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63A43D62B2549BA004CFEAA /* BuildDetails.swift */; };
+		B63A43E02B2603DD004CFEAA /* BuildDetails.plist in Resources */ = {isa = PBXBuildFile; fileRef = B63A43DF2B2603DD004CFEAA /* BuildDetails.plist */; };
+		B63A43E22B2603ED004CFEAA /* Scripts in Resources */ = {isa = PBXBuildFile; fileRef = B63A43E12B2603ED004CFEAA /* Scripts */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -457,6 +460,9 @@
 		A9F871242A2EBE63007EC235 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A9F8712A2A2EBE64007EC235 /* IntentsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IntentsUI.framework; path = System/Library/Frameworks/IntentsUI.framework; sourceTree = SDKROOT; };
 		A9F871642A2FF498007EC235 /* LoopCaregiverIntentExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LoopCaregiverIntentExtension.entitlements; sourceTree = "<group>"; };
+		B63A43D62B2549BA004CFEAA /* BuildDetails.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildDetails.swift; sourceTree = "<group>"; };
+		B63A43DF2B2603DD004CFEAA /* BuildDetails.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = BuildDetails.plist; sourceTree = SOURCE_ROOT; };
+		B63A43E12B2603ED004CFEAA /* Scripts */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Scripts; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -676,6 +682,7 @@
 				A92AB6BE2A3151E900977536 /* Extensions */,
 				A96929902927FFBA00B8BF43 /* AccountService.swift */,
 				A969293D2926EFEC00B8BF43 /* AccountServiceManager.swift */,
+				B63A43D62B2549BA004CFEAA /* BuildDetails.swift */,
 				A99F2F512A2A92D100F7DE2D /* Bundle+Extensions.swift */,
 				A90DB9532930F879004B58D3 /* CaregiverSettings.swift */,
 				A9972773292FC0B0006C8C74 /* CoreDataAccountService.swift */,
@@ -887,6 +894,8 @@
 		A9EC197A291FEF940022D39F /* LoopCaregiver */ = {
 			isa = PBXGroup;
 			children = (
+				B63A43E12B2603ED004CFEAA /* Scripts */,
+				B63A43DF2B2603DD004CFEAA /* BuildDetails.plist */,
 				A99F2F502A29398F00F7DE2D /* LoopCaregiver.entitlements */,
 				3DF4E0882980736C00E91E16 /* Info.plist */,
 				A96929302926E2B700B8BF43 /* Models */,
@@ -1005,6 +1014,7 @@
 				A95F50C2292A602F00079AAF /* Embed Frameworks */,
 				A9E14D3D2A2BA5A600BDB93D /* Embed Foundation Extensions */,
 				A9CFDD282AEBFF1400FA701B /* Embed Watch Content */,
+				B63A43DC2B254B4E004CFEAA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1143,7 +1153,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9EC1983291FEF950022D39F /* Preview Assets.xcassets in Resources */,
+				B63A43E02B2603DD004CFEAA /* BuildDetails.plist in Resources */,
 				A9EC1980291FEF950022D39F /* Assets.xcassets in Resources */,
+				B63A43E22B2603ED004CFEAA /* Scripts in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1155,6 +1167,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		B63A43DC2B254B4E004CFEAA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Scripts/capture-build-details.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A9346F7F2AC9820500C15F70 /* Sources */ = {
@@ -1312,6 +1344,7 @@
 				A9B033E629230FF20052AA9E /* OTPManager.swift in Sources */,
 				A95223672A7EDA9B0070FE13 /* BolusAction.swift in Sources */,
 				A9C4D7EE2969B70000D3875F /* NightscoutTreatment.swift in Sources */,
+				B63A43D72B2549BA004CFEAA /* BuildDetails.swift in Sources */,
 				A95223722A7EDCB90070FE13 /* NSRemoteCommandPayload.swift in Sources */,
 				A95F50C5292A648600079AAF /* PredictedGlucoseChartView.swift in Sources */,
 				A947025D2932299600FB3E59 /* ChartsListView.swift in Sources */,

--- a/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
+++ b/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
@@ -26,7 +26,6 @@ class BuildDetails {
     }
 
     var buildDateString: String? {
-        print(" *** build date,", dict["com-loopkit-Loop-build-date"] as? String)
         return dict["com-loopkit-Loop-build-date"] as? String
     }
 

--- a/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
+++ b/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
@@ -47,7 +47,6 @@ class BuildDetails {
     }
 
     var profileExpiration: Date? {
-        print(" *** profileExpiration,", dict["com-loopkit-Loop-profile-expiration"] as? String)
         return dict["com-loopkit-Loop-profile-expiration"] as? Date
     }
 

--- a/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
+++ b/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
@@ -26,27 +26,27 @@ class BuildDetails {
     }
 
     var buildDateString: String? {
-        return dict["com-loopkit-Loop-build-date"] as? String
+        return dict["com-app-build-date"] as? String
     }
 
     var xcodeVersion: String? {
-        return dict["com-loopkit-Loop-xcode-version"] as? String
+        return dict["com-app-xcode-version"] as? String
     }
 
     var gitRevision: String? {
-        return dict["com-loopkit-Loop-git-revision"] as? String
+        return dict["com-app-git-revision"] as? String
     }
 
     var gitBranch: String? {
-        return dict["com-loopkit-Loop-git-branch"] as? String
+        return dict["com-app-git-branch"] as? String
     }
 
     var sourceRoot: String? {
-        return dict["com-loopkit-Loop-srcroot"] as? String
+        return dict["com-app-srcroot"] as? String
     }
 
     var profileExpiration: Date? {
-        return dict["com-loopkit-Loop-profile-expiration"] as? Date
+        return dict["com-app-profile-expiration"] as? Date
     }
 
     var profileExpirationString: String {
@@ -59,11 +59,11 @@ class BuildDetails {
 
     // These strings are only configured if it is a workspace build
     var workspaceGitRevision: String? {
-        return dict["com-loopkit-LoopWorkspace-git-revision"] as? String
+        return dict["com-app-workspace-git-revision"] as? String
     }
 
     var workspaceGitBranch: String? {
-       return dict["com-loopkit-LoopWorkspace-git-branch"] as? String
+       return dict["com-app-workspace-git-branch"] as? String
    }
 }
 

--- a/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
+++ b/LoopCaregiver/LoopCaregiver/Models/BuildDetails.swift
@@ -1,0 +1,71 @@
+//
+//  BuildDetails.swift
+//  Loop
+//
+//  Created by Pete Schwamb on 6/13/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+class BuildDetails {
+
+    static var `default` = BuildDetails()
+
+    let dict: [String: Any]
+
+    init() {
+        guard let url = Bundle.main.url(forResource: "BuildDetails", withExtension: ".plist"),
+           let data = try? Data(contentsOf: url),
+           let parsed = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else
+        {
+            dict = [:]
+            return
+        }
+        dict = parsed
+    }
+
+    var buildDateString: String? {
+        print(" *** build date,", dict["com-loopkit-Loop-build-date"] as? String)
+        return dict["com-loopkit-Loop-build-date"] as? String
+    }
+
+    var xcodeVersion: String? {
+        return dict["com-loopkit-Loop-xcode-version"] as? String
+    }
+
+    var gitRevision: String? {
+        return dict["com-loopkit-Loop-git-revision"] as? String
+    }
+
+    var gitBranch: String? {
+        return dict["com-loopkit-Loop-git-branch"] as? String
+    }
+
+    var sourceRoot: String? {
+        return dict["com-loopkit-Loop-srcroot"] as? String
+    }
+
+    var profileExpiration: Date? {
+        print(" *** profileExpiration,", dict["com-loopkit-Loop-profile-expiration"] as? String)
+        return dict["com-loopkit-Loop-profile-expiration"] as? Date
+    }
+
+    var profileExpirationString: String {
+        if let profileExpiration = profileExpiration {
+            return "\(profileExpiration)"
+        } else {
+            return "N/A"
+        }
+    }
+
+    // These strings are only configured if it is a workspace build
+    var workspaceGitRevision: String? {
+        return dict["com-loopkit-LoopWorkspace-git-revision"] as? String
+    }
+
+    var workspaceGitBranch: String? {
+       return dict["com-loopkit-LoopWorkspace-git-branch"] as? String
+   }
+}
+

--- a/LoopCaregiver/LoopCaregiver/Models/Bundle+Extensions.swift
+++ b/LoopCaregiver/LoopCaregiver/Models/Bundle+Extensions.swift
@@ -8,8 +8,12 @@
 import Foundation
 
 extension Bundle {
+    
+    var bundleDisplayName: String {
+        return object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+    }
+    
     var appGroupSuiteName: String? {
-        //Should always defined in Xcode settings
         return object(forInfoDictionaryKey: "AppGroupIdentifier") as? String
     }
 }

--- a/LoopCaregiver/LoopCaregiver/Models/UserDefaults+Extensions.swift
+++ b/LoopCaregiver/LoopCaregiver/Models/UserDefaults+Extensions.swift
@@ -1,0 +1,26 @@
+//
+//  UserDefaults+Extensions.swift
+//  LoopCaregiver
+//
+//  Created by Bill Gestrich on 12/12/23.
+//
+
+import Foundation
+
+extension UserDefaults {
+    
+    private enum Key: String {
+        case lastProfileExpirationAlertDate = "com.loopkit.Loop.lastProfileExpirationAlertDate"
+    }
+    
+    public static let appGroup = UserDefaults(suiteName: Bundle.main.appGroupSuiteName)
+    
+    public var lastProfileExpirationAlertDate: Date? {
+        get {
+            return object(forKey: Key.lastProfileExpirationAlertDate.rawValue) as? Date
+        }
+        set {
+            set(newValue, forKey: Key.lastProfileExpirationAlertDate.rawValue)
+        }
+    }
+}

--- a/LoopCaregiver/LoopCaregiver/Views/Extensions/TimeInterval.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Extensions/TimeInterval.swift
@@ -13,4 +13,44 @@ extension TimeInterval {
         let minutes = (Int(self) - (hours * 3600)) / 60
         return (hours, minutes)
     }
+    
+    static func seconds(_ seconds: Double) -> TimeInterval {
+        return seconds
+    }
+
+    static func minutes(_ minutes: Double) -> TimeInterval {
+        return TimeInterval(minutes: minutes)
+    }
+
+    static func hours(_ hours: Double) -> TimeInterval {
+        return TimeInterval(hours: hours)
+    }
+
+    static func days(_ days: Double) -> TimeInterval {
+        return TimeInterval(days: days)
+    }
+
+    init(minutes: Double) {
+        self.init(minutes * 60)
+    }
+
+    init(hours: Double) {
+        self.init(minutes: hours * 60)
+    }
+
+    init(days: Double) {
+        self.init(hours: days * 24)
+    }
+
+    var minutes: Double {
+        return self / 60.0
+    }
+
+    var hours: Double {
+        return minutes / 60.0
+    }
+
+    var days: Double {
+        return hours / 24.0
+    }
 }

--- a/LoopCaregiver/LoopCaregiver/Views/Home/AppExpirationAlerterRepresentable.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Home/AppExpirationAlerterRepresentable.swift
@@ -1,0 +1,25 @@
+import LoopKitUI
+import SwiftUI
+import UIKit
+
+struct AppExpirationAlerterRepresentable: UIViewControllerRepresentable {
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        AppExpirationAlerterViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    }
+}
+
+class AppExpirationAlerterViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        NotificationCenter.default.addObserver(self, selector: #selector(appMovedToForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+    
+    @objc func appMovedToForeground() {
+        AppExpirationAlerter.alertIfNeeded(viewControllerToPresentFrom: self)
+    }
+}

--- a/LoopCaregiver/LoopCaregiver/Views/Home/ContentView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Home/ContentView.swift
@@ -44,6 +44,7 @@ struct ContentView: View {
                 Text("OK")
             }
         }
+        .background(AppExpirationAlerterRepresentable())
         
         @MainActor func handleDeepLinkURL(_ url: URL) async throws {
             

--- a/LoopCaregiver/LoopCaregiver/Views/Settings/AppExpirationAlerter.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Settings/AppExpirationAlerter.swift
@@ -1,0 +1,160 @@
+//
+//  AppExpirationAlerter.swift
+//  Loop
+//
+//  Created by Pete Schwamb on 8/21/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+
+
+class AppExpirationAlerter {
+    
+    static let expirationAlertWindow: TimeInterval = .days(20)
+    static let settingsPageExpirationWarningModeWindow: TimeInterval = .days(3)
+
+    static func alertIfNeeded(viewControllerToPresentFrom: UIViewController) {
+        
+        let now = Date()
+
+        guard let profileExpiration = BuildDetails.default.profileExpiration else {
+            return
+        }
+        
+        let expirationDate = calculateExpirationDate(profileExpiration: profileExpiration)
+        
+        let timeUntilExpiration = expirationDate.timeIntervalSince(now)
+        
+        if timeUntilExpiration > expirationAlertWindow {
+            return
+        }
+
+        let minimumTimeBetweenAlerts: TimeInterval = timeUntilExpiration > .hours(24) ? .days(2) : .hours(1)
+        
+        if let lastAlertDate = UserDefaults.appGroup?.lastProfileExpirationAlertDate {
+            guard now > lastAlertDate + minimumTimeBetweenAlerts else {
+                return
+            }
+        }
+        
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour]
+        formatter.unitsStyle = .full
+        formatter.zeroFormattingBehavior = .dropLeading
+        formatter.maximumUnitCount = 1
+        let timeUntilExpirationStr = formatter.string(from: timeUntilExpiration)
+        
+        let alertMessage = createVerboseAlertMessage(timeUntilExpirationStr: timeUntilExpirationStr!)
+        
+        var dialog: UIAlertController
+        if isTestFlightBuild() {
+            dialog = UIAlertController(
+                title: NSLocalizedString("TestFlight Expires Soon", comment: "The title for notification of upcoming TestFlight expiration"),
+                message: alertMessage,
+                preferredStyle: .alert)
+            dialog.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Text for ok action on notification of upcoming TestFlight expiration"), style: .default, handler: nil))
+            dialog.addAction(UIAlertAction(title: NSLocalizedString("More Info", comment: "Text for more info action on notification of upcoming TestFlight expiration"), style: .default, handler: { (_) in
+                UIApplication.shared.open(URL(string: "https://loopkit.github.io/loopdocs/gh-actions/gh-update/")!)
+            }))
+
+        } else {
+            dialog = UIAlertController(
+                title: NSLocalizedString("Profile Expires Soon", comment: "The title for notification of upcoming profile expiration"),
+                message: alertMessage,
+                preferredStyle: .alert)
+            dialog.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Text for ok action on notification of upcoming profile expiration"), style: .default, handler: nil))
+            dialog.addAction(UIAlertAction(title: NSLocalizedString("More Info", comment: "Text for more info action on notification of upcoming profile expiration"), style: .default, handler: { (_) in
+                UIApplication.shared.open(URL(string: "https://loopkit.github.io/loopdocs/build/updating/")!)
+            }))
+        }
+        viewControllerToPresentFrom.present(dialog, animated: true, completion: nil)
+        
+        UserDefaults.appGroup?.lastProfileExpirationAlertDate = now
+    }
+    
+    static func createVerboseAlertMessage(timeUntilExpirationStr:String) -> String {
+        if isTestFlightBuild() {
+            return String(format: NSLocalizedString("%1$@ will stop working in %2$@. You will need to rebuild before that.", comment: "Format string for body for notification of upcoming expiration. (1: app name) (2: amount of time until expiration"), Bundle.main.bundleDisplayName, timeUntilExpirationStr)
+        } else {
+            return String(format: NSLocalizedString("%1$@ will stop working in %2$@. You will need to update before that, with a new provisioning profile.", comment: "Format string for body for notification of upcoming provisioning profile expiration. (1: app name) (2: amount of time until expiration"), Bundle.main.bundleDisplayName, timeUntilExpirationStr)
+        }
+    }
+    
+    static func isNearExpiration(expirationDate:Date) -> Bool {
+        return expirationDate.timeIntervalSinceNow < settingsPageExpirationWarningModeWindow
+    }
+    
+    static func createProfileExpirationSettingsMessage(expirationDate:Date) -> String {
+        let nearExpiration = isNearExpiration(expirationDate: expirationDate)
+        let maxUnitCount = nearExpiration ? 2 : 1 // only include hours in the msg if near expiration
+        let readableRelativeTime: String? = relativeTimeFormatter(maxUnitCount: maxUnitCount).string(from: expirationDate.timeIntervalSinceNow)
+        let relativeTimeRemaining: String = readableRelativeTime ?? NSLocalizedString("Unknown time", comment: "Unknown amount of time in settings' profile expiration section")
+        let verboseMessage = createVerboseAlertMessage(timeUntilExpirationStr: relativeTimeRemaining)
+        let conciseMessage = relativeTimeRemaining + NSLocalizedString(" remaining", comment: "remaining time in setting's profile expiration section")
+        return nearExpiration ? verboseMessage : conciseMessage
+    }
+    
+    private static func relativeTimeFormatter(maxUnitCount:Int) -> DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        let includeHours = maxUnitCount == 2
+        formatter.allowedUnits = includeHours ? [.day, .hour] :  [.day]
+        formatter.unitsStyle = .full
+        formatter.zeroFormattingBehavior = .dropLeading
+        formatter.maximumUnitCount = maxUnitCount
+        return formatter
+    }
+    
+    static func buildDate() -> Date? {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "EEE MMM d HH:mm:ss 'UTC' yyyy"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX") // Set locale to ensure parsing works
+        dateFormatter.timeZone = TimeZone(identifier: "UTC")
+        
+        guard let dateString = BuildDetails.default.buildDateString,
+              let date = dateFormatter.date(from: dateString) else {
+            return nil
+        }
+        
+        return date
+    }
+    
+    static func isTestFlightBuild() -> Bool {
+        // If the target environment is a simulator, then
+        // this is not a TestFlight distribution. Return false.
+        #if targetEnvironment(simulator)
+        return false
+        #else
+
+        // If an "embedded.mobileprovision" is present in the main bundle, then
+        // this is an Xcode, Ad-Hoc, or Enterprise distribution. Return false.
+        if Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision") != nil {
+            return false
+        }
+
+        // If an app store receipt is not present in the main bundle, then we cannot
+        // say whether this is a TestFlight or App Store distribution. Return false.
+        guard let receiptName = Bundle.main.appStoreReceiptURL?.lastPathComponent else {
+            return false
+        }
+
+        // A TestFlight distribution presents a "sandboxReceipt", while an App Store
+        // distribution presents a "receipt". Return true if we have a TestFlight receipt.
+        return "sandboxReceipt".caseInsensitiveCompare(receiptName) == .orderedSame
+        #endif
+    }
+
+    static func calculateExpirationDate(profileExpiration: Date) -> Date {
+        let isTestFlight = isTestFlightBuild()
+        
+        if isTestFlight, let buildDate = buildDate() {
+            let testflightExpiration = Calendar.current.date(byAdding: .day, value: 90, to: buildDate)!
+            
+            return profileExpiration < testflightExpiration ? profileExpiration : testflightExpiration
+        } else {
+            return profileExpiration
+        }
+    }
+}

--- a/LoopCaregiver/LoopCaregiver/Views/Settings/SettingsView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Settings/SettingsView.swift
@@ -5,8 +5,10 @@
 //  Created by Bill Gestrich on 11/13/22.
 //
 
-import SwiftUI
 import Combine
+import LoopKitUI
+import SwiftUI
+
 
 struct SettingsView: View {
 
@@ -38,7 +40,9 @@ struct SettingsView: View {
                 commandsSection
                 unitsSection
                 timelineSection
-                expirationSection
+                if let profileExpiration = BuildDetails.default.profileExpiration {
+                    appExpirationSection(profileExpiration: profileExpiration)
+                }
                 experimentalSection
             }
             .navigationBarTitle(Text("Settings"), displayMode: .inline)
@@ -121,33 +125,27 @@ struct SettingsView: View {
     }
     
     var unitsSection: some View {
-        Section("Units") {
+        Section {
             Picker("Glucose", selection: $glucosePreference, content: {
                 ForEach(GlucoseUnitPrefererence.allCases, id: \.self, content: { item in
                     Text(item.presentableDescription).tag(item)
                 })
             })
+        } header: {
+            SectionHeader(label: "Units")
         }
     }
     
     var timelineSection: some View {
-        Section("Timeline") {
+        Section {
             Toggle("Show Prediction", isOn: $settings.timelinePredictionEnabled)
+        }  header: {
+            SectionHeader(label: "Timeline")
         }
     }
-
-    var expirationSection: some View {
-        Section("Expiration") {
-            VStack {
-                Text(expireTitleString())
-                // quick and dirty truncation of date string
-                Text(expireDateString().prefix(16))
-            }
-        }
-    }
-
+    
     var experimentalSection: some View {
-        Section("Experimental Features") {
+        Section {
             if settings.experimentalFeaturesUnlocked || settings.remoteCommands2Enabled {
                 Toggle("Remote Commands 2", isOn: $settings.remoteCommands2Enabled)
                 Text("Remote commands 2 requires a special Nightscout deploy and Loop version. This will enable command status and other features. See Zulip #caregiver for details")
@@ -174,6 +172,8 @@ struct SettingsView: View {
                         settings.experimentalFeaturesUnlocked = true
                     })
             }
+        }  header: {
+            SectionHeader(label: "Experimental Features")
         }
     }
     
@@ -269,75 +269,7 @@ struct SettingsView: View {
             }
         }
     }
-
-    // copied from LoopWorkspace/Loop/Loop/Managers/AppExpirationAlerter.swift
-    func isTestFlightBuild() -> Bool {
-
-        // uncomment next for quick and dirty testflight test
-        //return true
-
-        // If the target environment is a simulator, then
-        // this is not a TestFlight distribution. Return false.
-        #if targetEnvironment(simulator)
-        return false
-        #else
-
-        // If an "embedded.mobileprovision" is present in the main bundle, then
-        // this is an Xcode, Ad-Hoc, or Enterprise distribution. Return false.
-        if Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision") != nil {
-            return false
-        }
-
-        // If an app store receipt is not present in the main bundle, then we cannot
-        // say whether this is a TestFlight or App Store distribution. Return false.
-        guard let receiptName = Bundle.main.appStoreReceiptURL?.lastPathComponent else {
-            return false
-        }
-
-        // A TestFlight distribution presents a "sandboxReceipt", while an App Store
-        // distribution presents a "receipt". Return true if we have a TestFlight receipt.
-        return "sandboxReceipt".caseInsensitiveCompare(receiptName) == .orderedSame
-        #endif
-    }
-
-    func buildDate() -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "EEE MMM d HH:mm:ss 'UTC' yyyy"
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX") // Set locale to ensure parsing works
-        dateFormatter.timeZone = TimeZone(identifier: "UTC")
-
-        guard let dateString = BuildDetails.default.buildDateString,
-              let date = dateFormatter.date(from: dateString) else {
-            return nil
-        }
-
-        return date
-    }
-
-    func expireTitleString() -> String {
-        if isTestFlightBuild() {
-            return "TestFlight Expiration"
-        } else {
-            return "Profile Expiration"
-        }
-    }
-
-    func expireDateString() -> String {
-        if isTestFlightBuild() {
-            // expireDate for true returns "N/A" - please find my mistake
-            let buildDate = buildDate()
-            if buildDate == nil {
-                print(" *** buildDate is nil")
-                return "N/A"
-            }
-            let expireDate = Calendar.current.date(byAdding: .day, value: 90, to: buildDate!)
-            return "\(expireDate)"
-        } else {
-            let profileExpireString = BuildDetails.default.profileExpirationString
-            return profileExpireString
-        }
-    }
-
+    
     var remoteCommandSectionText: String {
         if looperService.settings.remoteCommands2Enabled {
             return "Remote Commands"
@@ -345,6 +277,67 @@ struct SettingsView: View {
             return "Remote Command Errors"
         }
     }
+    
+    /*
+     DIY loop specific component to show users the amount of time remaining on their build before a rebuild is necessary.
+     */
+    private func appExpirationSection(profileExpiration: Date) -> some View {
+        let expirationDate = AppExpirationAlerter.calculateExpirationDate(profileExpiration: profileExpiration)
+        let isTestFlight = AppExpirationAlerter.isTestFlightBuild()
+        let nearExpiration = AppExpirationAlerter.isNearExpiration(expirationDate: expirationDate)
+        let profileExpirationMsg = AppExpirationAlerter.createProfileExpirationSettingsMessage(expirationDate: expirationDate)
+        let readableExpirationTime = Self.dateFormatter.string(from: expirationDate)
+        
+        if isTestFlight {
+            return createAppExpirationSection(
+                headerLabel: NSLocalizedString("TestFlight", comment: "Settings app TestFlight section"),
+                footerLabel: NSLocalizedString("TestFlight expires ", comment: "Time that build expires") + readableExpirationTime,
+                expirationLabel: NSLocalizedString("TestFlight Expiration", comment: "Settings TestFlight expiration view"),
+                updateURL: "https://loopkit.github.io/loopdocs/gh-actions/gh-update/",
+                nearExpiration: nearExpiration,
+                expirationMessage: profileExpirationMsg
+            )
+        } else {
+            return createAppExpirationSection(
+                headerLabel: NSLocalizedString("App Profile", comment: "Settings app profile section"),
+                footerLabel: NSLocalizedString("Profile expires ", comment: "Time that profile expires") + readableExpirationTime,
+                expirationLabel: NSLocalizedString("Profile Expiration", comment: "Settings App Profile expiration view"),
+                updateURL: "https://loopkit.github.io/loopdocs/build/updating/",
+                nearExpiration: nearExpiration,
+                expirationMessage: profileExpirationMsg
+            )
+        }
+    }
+    
+    private func createAppExpirationSection(headerLabel: String, footerLabel: String, expirationLabel: String, updateURL: String, nearExpiration: Bool, expirationMessage: String) -> some View {
+        return Section(
+            header: SectionHeader(label: headerLabel),
+            footer: Text(footerLabel)
+        ) {
+            if nearExpiration {
+                Text(expirationMessage).foregroundColor(.red)
+            } else {
+                HStack {
+                    Text(expirationLabel)
+                    Spacer()
+                    Text(expirationMessage).foregroundColor(Color.secondary)
+                }
+            }
+            Button(action: {
+                UIApplication.shared.open(URL(string: updateURL)!)
+            }) {
+                Text(NSLocalizedString("How to update (LoopDocs)", comment: "The title text for how to update"))
+            }
+        }
+    }
+
+    private static var dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .short
+        return dateFormatter // formats date like "February 4, 2023 at 2:35 PM"
+    }()
+
 }
 
 class SettingsViewModel: ObservableObject {

--- a/LoopCaregiver/Scripts/capture-build-details.sh
+++ b/LoopCaregiver/Scripts/capture-build-details.sh
@@ -54,25 +54,24 @@ info "Gathering build details in ${PWD}"
 
 if [ -e .git ]; then
   rev=$(git rev-parse HEAD)
-  plutil -replace com-loopkit-Loop-git-revision -string ${rev:0:7} "${info_plist_path}"
+  plutil -replace com-app-git-revision -string ${rev:0:7} "${info_plist_path}"
   branch=$(git branch --show-current)
   if [ -n "$branch" ]; then
-    plutil -replace com-loopkit-Loop-git-branch -string "${branch}" "${info_plist_path}"
+    plutil -replace com-app-git-branch -string "${branch}" "${info_plist_path}"
   else
-    warn "No git branch found, not setting com-loopkit-Loop-git-branch"
+    warn "No git branch found, not setting com-app-git-branch"
   fi
 fi
 
-plutil -replace com-loopkit-Loop-srcroot -string "${PWD}" "${info_plist_path}"
-plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"
-build_date_string="$(date)"
-plutil -replace com-loopkit-Loop-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
+plutil -replace com-app-srcroot -string "${PWD}" "${info_plist_path}"
+plutil -replace com-app-build-date -string "$(date)" "${info_plist_path}"
+plutil -replace com-app-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
 
 if [ -e "${provisioning_profile_path}" ]; then
   profile_expire_date=$(security cms -D -i "${provisioning_profile_path}" | plutil -p - | grep ExpirationDate | cut -b 23-)
   # Convert to plutil format
   profile_expire_date=$(date -j -f "%Y-%m-%d %H:%M:%S" "${profile_expire_date}" +"%Y-%m-%dT%H:%M:%SZ")
-  plutil -replace com-loopkit-Loop-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
+  plutil -replace com-app-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
 else
   warn "Invalid provisioning profile path ${provisioning_profile_path}"
 fi
@@ -84,17 +83,10 @@ then
     pushd . > /dev/null
     cd ..
     rev=$(git rev-parse HEAD)
-    plutil -replace com-loopkit-LoopWorkspace-git-revision -string "${rev:0:7}" "${info_plist_path}"
+    plutil -replace com-app-workspace-git-revision -string "${rev:0:7}" "${info_plist_path}"
     branch=$(git branch --show-current)
     if [ -n "$branch" ]; then
-        plutil -replace com-loopkit-LoopWorkspace-git-branch -string "${branch}" "${info_plist_path}"
+        plutil -replace com-app-workspace-git-branch -string "${branch}" "${info_plist_path}"
     fi
     popd . > /dev/null
 fi
-
-# report all the variables to make sure they were captured
-info "info_plist_path, ${info_plist_path}"
-info "branch, ${branch}"
-info "provisioning_profile_path, ${provisioning_profile_path}"
-info "profile_expire_date, ${profile_expire_date}"
-info "build date, ${build_date_string}"

--- a/LoopCaregiver/Scripts/capture-build-details.sh
+++ b/LoopCaregiver/Scripts/capture-build-details.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 #  capture-build-details.sh
-#  LoopCaregiver
+#  Loop
 #
 #  Copyright © 2019 LoopKit Authors. All rights reserved.
 
@@ -84,10 +84,10 @@ then
     pushd . > /dev/null
     cd ..
     rev=$(git rev-parse HEAD)
-    plutil -replace com-loopkit-Loop-git-revision -string "${rev:0:7}" "${info_plist_path}"
+    plutil -replace com-loopkit-LoopWorkspace-git-revision -string "${rev:0:7}" "${info_plist_path}"
     branch=$(git branch --show-current)
     if [ -n "$branch" ]; then
-        plutil -replace com-loopkit-Loop-git-branch -string "${branch}" "${info_plist_path}"
+        plutil -replace com-loopkit-LoopWorkspace-git-branch -string "${branch}" "${info_plist_path}"
     fi
     popd . > /dev/null
 fi

--- a/LoopCaregiver/Scripts/capture-build-details.sh
+++ b/LoopCaregiver/Scripts/capture-build-details.sh
@@ -1,0 +1,100 @@
+#!/bin/sh -e
+
+#  capture-build-details.sh
+#  LoopCaregiver
+#
+#  Copyright © 2019 LoopKit Authors. All rights reserved.
+
+SCRIPT="$(basename "${0}")"
+SCRIPT_DIRECTORY="$(dirname "${0}")"
+
+error() {
+  echo "ERROR: ${*}" >&2
+  echo "Usage: ${SCRIPT} [-r|--git-source-root git-source-root] [-p|--provisioning-profile-path provisioning-profile-path]" >&2
+  echo "Parameters:" >&2
+  echo "  -p|--provisioning-profile-path <provisioning-profile-path> path to the .mobileprovision provisioning profile file to check for expiration; optional, defaults to \${HOME}/Library/MobileDevice/Provisioning Profiles/\${EXPANDED_PROVISIONING_PROFILE}.mobileprovision" >&2
+  exit 1
+}
+
+warn() {
+  echo "WARN: ${*}" >&2
+}
+
+info() {
+  echo "INFO: ${*}" >&2
+}
+
+info_plist_path="${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/BuildDetails.plist"
+provisioning_profile_path="${HOME}/Library/MobileDevice/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision"
+xcode_build_version=${XCODE_PRODUCT_BUILD_VERSION:-$(xcodebuild -version | grep version | cut -d ' ' -f 3)}
+while [[ $# -gt 0 ]]
+do
+  case $1 in
+    -i|--info-plist-path)
+      info_plist_path="${2}"
+      shift 2
+      ;;
+    -p|--provisioning-profile-path)
+      provisioning_profile_path="${2}"
+      shift 2
+      ;;
+  esac
+done
+
+if [ ${#} -ne 0 ]; then
+  error "Unexpected arguments: ${*}"
+fi
+
+if [ "${info_plist_path}" == "/" -o ! -e "${info_plist_path}" ]; then
+  error "File does not exist: ${info_plist_path}"
+  #error "Must provide valid --info-plist-path, or have valid \${BUILT_PRODUCTS_DIR} and \${INFOPLIST_PATH} set."
+fi
+
+info "Gathering build details in ${PWD}"
+
+if [ -e .git ]; then
+  rev=$(git rev-parse HEAD)
+  plutil -replace com-loopkit-Loop-git-revision -string ${rev:0:7} "${info_plist_path}"
+  branch=$(git branch --show-current)
+  if [ -n "$branch" ]; then
+    plutil -replace com-loopkit-Loop-git-branch -string "${branch}" "${info_plist_path}"
+  else
+    warn "No git branch found, not setting com-loopkit-Loop-git-branch"
+  fi
+fi
+
+plutil -replace com-loopkit-Loop-srcroot -string "${PWD}" "${info_plist_path}"
+plutil -replace com-loopkit-Loop-build-date -string "$(date)" "${info_plist_path}"
+build_date_string="$(date)"
+plutil -replace com-loopkit-Loop-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
+
+if [ -e "${provisioning_profile_path}" ]; then
+  profile_expire_date=$(security cms -D -i "${provisioning_profile_path}" | plutil -p - | grep ExpirationDate | cut -b 23-)
+  # Convert to plutil format
+  profile_expire_date=$(date -j -f "%Y-%m-%d %H:%M:%S" "${profile_expire_date}" +"%Y-%m-%dT%H:%M:%SZ")
+  plutil -replace com-loopkit-Loop-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
+else
+  warn "Invalid provisioning profile path ${provisioning_profile_path}"
+fi
+
+# determine if this is a workspace build
+# if so, fill out the git revision and branch
+if [ -e ../.git ]
+then
+    pushd . > /dev/null
+    cd ..
+    rev=$(git rev-parse HEAD)
+    plutil -replace com-loopkit-Loop-git-revision -string "${rev:0:7}" "${info_plist_path}"
+    branch=$(git branch --show-current)
+    if [ -n "$branch" ]; then
+        plutil -replace com-loopkit-Loop-git-branch -string "${branch}" "${info_plist_path}"
+    fi
+    popd . > /dev/null
+fi
+
+# report all the variables to make sure they were captured
+info "info_plist_path, ${info_plist_path}"
+info "branch, ${branch}"
+info "provisioning_profile_path, ${provisioning_profile_path}"
+info "profile_expire_date, ${profile_expire_date}"
+info "build date, ${build_date_string}"


### PR DESCRIPTION
Current Status:
* Merged updates from Bill Gestrich
* Works for Mac-Xcode test but puzzled by difference with Loop
  * Compare expiration to Loop built right after LoopCaregiver (no change to mobile provisioning)
  * LoopCaregiver 359 days, Dec 7 2024 at 17:22
  * Loop 352 days, Nov 30 2024 at 16:24
* Works for TestFlight and agrees with what TestFlight reports
   * within error range - we add 90 days and sometimes TestFlight says expires in 91 days
   * LoopCaregiver says 89 days remaining, March 13, 2024 at 07:40 (now 08:00)
   * TestFlight says expires in 91 days
   * Advanced test phone time to March 14 and get "LoopCaregiver" Beta Has Expired
   * Changed test phone time to March 12 and get TestFlight Expires soon modal alert

For both Mac-Xcode and GitHub build, link goes to appropriate LoopDocs page.

Original Status:
Status
* Copied build information gathering code from Loop
* Copied TestFlight detection code from Loop
* Add an expiration section to SettingsView.swift

What happens now: 
* for xcode build, expiration date is 1 year from build date - but Loop uses actual profile expiration data
* for "fake" testflight (I hack a return true inside isTestFlightBuild) - buildDate is nil, so get "N/A" for expiration