### PR TITLE
Watch - rectangle widget view

### DIFF
--- a/LoopCaregiver/LoopCaregiverWatchAppExtension/LoopCaregiverWatchAppExtension.swift
+++ b/LoopCaregiver/LoopCaregiverWatchAppExtension/LoopCaregiverWatchAppExtension.swift
@@ -66,6 +66,8 @@ struct WidgetView: View {
     @ViewBuilder
     var body: some View {
         switch family {
+        case .accessoryRectangular:
+            LatestGlucoseRectangularView(viewModel: viewModel)
         case .accessoryInline:
             LatestGlucoseInlineView(viewModel: viewModel)
         default:

--- a/LoopCaregiver/LoopCaregiverWidgetExtension/LoopCaregiverWidgetView.swift
+++ b/LoopCaregiver/LoopCaregiverWidgetExtension/LoopCaregiverWidgetView.swift
@@ -38,6 +38,12 @@ struct LoopCaregiverWidgetView : View {
         Group {
             if settings.appGroupsSupported {
                 switch family {
+                case .accessoryRectangular:
+                    if let latestGlucoseSample = entry.currentGlucoseSample {
+                        LatestGlucoseRectangularView(viewModel: WidgetViewModel(timelineEntryDate: entry.date, latestGlucose: latestGlucoseSample, lastGlucoseChange: entry.lastGlucoseChange, isLastEntry: entry.isLastEntry, glucoseDisplayUnits: settings.glucoseDisplayUnits, looper: entry.looper))
+                    } else {
+                        emptyLatestGlucoseView
+                    }
                 case .accessoryCircular:
                     if let latestGlucoseSample = entry.currentGlucoseSample {
                         LatestGlucoseCircularView(viewModel: WidgetViewModel(timelineEntryDate: entry.date, latestGlucose: latestGlucoseSample, lastGlucoseChange: entry.lastGlucoseChange, isLastEntry: entry.isLastEntry, glucoseDisplayUnits: settings.glucoseDisplayUnits, looper: entry.looper))
@@ -49,6 +55,8 @@ struct LoopCaregiverWidgetView : View {
                 }
             } else {
                 switch family {
+                case .accessoryRectangular:
+                   Text("AppGroups?")
                 case .accessoryCircular:
                    Text("AppGroups?")
                 default:

--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
@@ -1,0 +1,67 @@
+//
+//  LatestGlucoseRectangularView.swift
+//  LoopCaregiverWidgetExtension
+//
+//  Created by Auggie Fisher on 1/24/24.
+//
+
+import HealthKit
+import LoopCaregiverKit
+import LoopKit
+import SwiftUI
+
+public struct LatestGlucoseRectangularView: View {
+
+    
+    public let viewModel: WidgetViewModel
+    @Environment(\.colorScheme) var colorScheme
+    
+    public init(viewModel: WidgetViewModel) {
+        self.viewModel = viewModel
+    }
+    
+    public var body: some View {
+        
+        HStack (spacing: 10) {
+            VStack {
+                //BG number
+                Text(viewModel.currentGlucoseNumberText)
+                    .foregroundStyle(egvColor)
+                    .strikethrough(viewModel.isGlucoseStale)
+                    .font(.system(size: 70.0))
+            }
+            VStack (spacing: 0) {
+                HStack {
+                    //Trend arrow
+                    if let currentTrendImageName = viewModel.currentTrendImageName {
+                        Image(systemName: currentTrendImageName)
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: 12)
+                            .offset(.init(width: 0.0, height: 1.0))
+                    }
+                    //BG delta
+                    Text(viewModel.lastGlucoseChangeFormatted!)
+                        .strikethrough(viewModel.isGlucoseStale)
+                        .font(.system(size: 20.0))
+                }
+                //Minutes since update
+                Text("~" + viewModel.currentGlucoseDateText)
+                    .strikethrough(viewModel.isGlucoseStale)
+                    .font(.system(size: 20.0))
+            }
+        }
+    }
+    
+    var egvColor: Color {
+        colorScheme == .dark ? viewModel.egvValueColor : .primary
+    }
+    
+}
+
+struct LatestGlucoseRectangularView_Previews: PreviewProvider {
+    static var previews: some View {
+        let latestGlucose = NewGlucoseSample(date: Date(), quantity: .init(unit: .gramsPerUnit, doubleValue: 1.0), condition: .aboveRange, trend: .down, trendRate: .none, isDisplayOnly: false, wasUserEntered: false, syncIdentifier: "12345")
+        let viewModel = WidgetViewModel(timelineEntryDate: Date(), latestGlucose: latestGlucose, lastGlucoseChange: 3, isLastEntry: true, glucoseDisplayUnits: .gramsPerUnit, looper: nil)
+    }
+}

--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
@@ -46,7 +46,7 @@ public struct LatestGlucoseRectangularView: View {
                         .font(.system(size: 20.0))
                 }
                 //Minutes since update
-                Text("~" + viewModel.currentGlucoseDateText)
+                Text(viewModel.currentGlucoseDateText)
                     .strikethrough(viewModel.isGlucoseStale)
                     .font(.system(size: 20.0))
             }

--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
@@ -38,7 +38,7 @@ public struct LatestGlucoseRectangularView: View {
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(maxWidth: 12)
-                            .offset(.init(width: 0.0, height: 1.0))
+                            .offset(.init(width: 0.0, height: 1.5))
                     }
                     //BG delta
                     Text(viewModel.lastGlucoseChangeFormatted!)

--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
@@ -28,7 +28,7 @@ public struct LatestGlucoseRectangularView: View {
                 Text(viewModel.currentGlucoseNumberText)
                     .foregroundStyle(egvColor)
                     .strikethrough(viewModel.isGlucoseStale)
-                    .font(.system(size: 65))
+                    .font(.system(size: 65.0))
             }
             VStack (spacing: 0) {
                 HStack {

--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
@@ -28,7 +28,7 @@ public struct LatestGlucoseRectangularView: View {
                 Text(viewModel.currentGlucoseNumberText)
                     .foregroundStyle(egvColor)
                     .strikethrough(viewModel.isGlucoseStale)
-                    .font(.system(size: 70.0))
+                    .font(.system(size: 65))
             }
             VStack (spacing: 0) {
                 HStack {

--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/WidgetViewModel.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/WidgetViewModel.swift
@@ -54,6 +54,14 @@ public struct WidgetViewModel {
         return toRet
     }
     
+    public var currentGlucoseNumberText: String {
+        var toRet = ""
+        let latestGlucoseValue = latestGlucose.presentableStringValue(displayUnits: glucoseDisplayUnits)
+        toRet += "\(latestGlucoseValue)"
+        
+        return toRet
+    }
+    
     public var lastGlucoseChangeFormatted: String? {
         
         guard let lastGlucoseChange = lastGlucoseChange else {return nil}


### PR DESCRIPTION
* Large fonts and layout to make use of extra space in rectangle view
* Using the same data sources as other widgets, just an optimized view for larger rectangle area
* Sample images below (Apple Watch Ultra 1, Apple Watch Series 7 (41mm)
![incoming-CA37BA23-00B5-49AC-91D5-D2879ACD7258](https://github.com/LoopKit/LoopCaregiver/assets/659845/4261cd2b-cc8f-43a0-8c16-4658e9b4a814)
![incoming-BAD1A3CD-47D6-4522-917E-FBD4F9E4B1C4](https://github.com/LoopKit/LoopCaregiver/assets/659845/3d5ce17b-e0e5-41d5-a831-5a1dadffebd0)
![image](https://github.com/LoopKit/LoopCaregiver/assets/659845/324f7f4b-89f2-4930-b155-85d41115ee8f)