### PR TITLE
Maximize use of real estate in Home view of Watch app

### DIFF
--- a/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
+++ b/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
@@ -28,28 +28,38 @@ struct HomeView: View {
     }
     
     var body: some View {
-        VStack {
+        VStack  (spacing: 0) {
+            //BG number
             HStack {
                 Text(remoteDataSource.currentGlucoseSample?.presentableStringValue(displayUnits: settings.glucoseDisplayUnits) ?? " ")
                     .strikethrough(egvIsOutdated())
-                    .font(.largeTitle)
+                    .font(.custom("SF Compact", fixedSize:50))
                     .foregroundColor(egvValueColor())
+            }
+            //Trend arrow
+            HStack {
                 if let egv = remoteDataSource.currentGlucoseSample {
                     Image(systemName: egv.arrowImageName())
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width: 15.0)
-                        .foregroundColor(egvValueColor())
+                        .frame(width:35.0)
+                        .offset(.init(width: 0.0, height: 4.0))
                 }
-                VStack {
-                    Text(lastEGVTimeFormatted())
-                        .font(.footnote)
-                        .if(egvIsOutdated(), transform: { view in
-                            view.foregroundColor(.red)
-                        })
-                            Text(lastEGVDeltaFormatted())
-                            .font(.footnote)
-                }
+                //BG delta
+                Text(lastEGVDeltaFormatted())
+                    .strikethrough(egvIsOutdated())
+                    .font(.custom("SF Compact", fixedSize:40))
+                
+            }
+            //Time since last reading in mm:ss format
+            HStack {
+                Text(durSinceEGV())
+                    .font(.custom("SF Compact", fixedSize:30))
+                Text("ago")
+                    .font(.custom("SF Compact", fixedSize:30))
+                    .if(egvIsOutdated(), transform: { view in
+                        view.foregroundColor(.red)
+                    })
             }
         }
         .navigationTitle(accountService.selectedLooper?.name ?? "Name?")
@@ -100,6 +110,28 @@ struct HomeView: View {
         }
         
         return currentEGV.date.formatted(.dateTime.hour().minute())
+    }
+    
+    //Minutes since last BG reading
+    func minSinceEGV() -> String {
+        guard let currentEGV = remoteDataSource.currentGlucoseSample else {
+            return "0"
+        }
+        return String(Int(Date().timeIntervalSince(currentEGV.date)) / 60)
+    }
+    
+    //Seconds since last BG reading
+    func secSinceEGV() -> String {
+        guard let currentEGV = remoteDataSource.currentGlucoseSample else {
+            return "00"
+        }
+        let seconds = Int(Date().timeIntervalSince(currentEGV.date)) % 60
+        return(String(format: "%02d", seconds))
+    }
+    
+    //Time since last reading in mm:ss
+    func durSinceEGV() -> String {
+        return minSinceEGV() + ":" + secSinceEGV()
     }
     
     func egvIsOutdated() -> Bool {

--- a/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
+++ b/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
@@ -43,7 +43,7 @@ struct HomeView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width:35.0)
-                        .offset(.init(width: 0.0, height: 4.0))
+                        .offset(.init(width: 0.0, height: 3.0))
                 }
                 //BG delta
                 Text(lastEGVDeltaFormatted())

--- a/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
+++ b/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
@@ -19,6 +19,8 @@ struct HomeView: View {
     @ObservedObject var looperService: LooperService
     @Environment(\.scenePhase) var scenePhase
     
+    var homeViewTextMultiplier = 1.20
+    
     init(connectivityManager: WatchService, looperService: LooperService){
         self.connectivityManager = connectivityManager
         self.looperService = looperService
@@ -28,38 +30,33 @@ struct HomeView: View {
     }
     
     var body: some View {
-        VStack  (spacing: 0) {
-            //BG number
-            HStack {
-                Text(remoteDataSource.currentGlucoseSample?.presentableStringValue(displayUnits: settings.glucoseDisplayUnits) ?? " ")
+        HStack (spacing: 10) {
+            VStack {
+                //BG number
+                Text(remoteDataSource.currentGlucoseSample?.presentableStringValue(displayUnits: settings.glucoseDisplayUnits) ?? "??")
                     .strikethrough(egvIsOutdated())
-                    .font(.custom("SF Compact", fixedSize:50))
+                    .font(.system(size: 60.0 * homeViewTextMultiplier))
                     .foregroundColor(egvValueColor())
             }
-            //Trend arrow
-            HStack {
-                if let egv = remoteDataSource.currentGlucoseSample {
-                    Image(systemName: egv.arrowImageName())
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width:25.0)
-                        .offset(.init(width: 0.0, height: 3.0))
+            VStack (spacing: 0) {
+                HStack {
+                    //Trend arrow
+                    if let egv = remoteDataSource.currentGlucoseSample {
+                        Image(systemName: egv.arrowImageName())
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(maxWidth: 12 * homeViewTextMultiplier)
+                            .offset(.init(width: 0.0, height: 1.5 * homeViewTextMultiplier))
+                    }
+                    //BG delta
+                    Text(lastEGVDeltaFormatted())
+                        .strikethrough(egvIsOutdated())
+                        .font(.system(size: 20.0 * homeViewTextMultiplier))
                 }
-                //BG delta
-                Text(lastEGVDeltaFormatted())
-                    .strikethrough(egvIsOutdated())
-                    .font(.custom("SF Compact", fixedSize:40))
-                
-            }
-            //Time since last reading in mm:ss format
-            HStack {
+                //Minutes since update
                 Text(durSinceEGV())
-                    .font(.custom("SF Compact", fixedSize:30))
-                Text("ago")
-                    .font(.custom("SF Compact", fixedSize:30))
-                    .if(egvIsOutdated(), transform: { view in
-                        view.foregroundColor(.red)
-                    })
+                    .strikethrough(egvIsOutdated())
+                    .font(.system(size: 20.0 * homeViewTextMultiplier))
             }
         }
         .navigationTitle(accountService.selectedLooper?.name ?? "Name?")

--- a/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
+++ b/LoopCaregiver/LoopCaregiverWatchApp/HomeView.swift
@@ -42,7 +42,7 @@ struct HomeView: View {
                     Image(systemName: egv.arrowImageName())
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(width:35.0)
+                        .frame(width:25.0)
                         .offset(.init(width: 0.0, height: 3.0))
                 }
                 //BG delta


### PR DESCRIPTION
* Bigger fonts in the Watch app Home view
* Re-organize the sequence of info shown in the Watch app Home view
* Include mm:ss format since last reading in the Watch app Home view
* Tested in Apple Watch Ultra (1) and Apple Watch Series 7 (41mm)
![image](https://github.com/LoopKit/LoopCaregiver/assets/659845/1eca6c00-f060-4230-be95-8f8aad7e925e)