### PR TITLE
Reduce size of BG text in watch rectangle widget

### DIFF
--- a/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKitUI/LatestGlucoseRectangularView.swift
@@ -28,7 +28,7 @@ public struct LatestGlucoseRectangularView: View {
                 Text(viewModel.currentGlucoseNumberText)
                     .foregroundStyle(egvColor)
                     .strikethrough(viewModel.isGlucoseStale)
-                    .font(.system(size: 65.0))
+                    .font(.system(size: 60.0))
             }
             VStack (spacing: 0) {
                 HStack {


### PR DESCRIPTION
* Text clipping reported for some BGs on some watches
* Unable to confirm this smaller text addresses the issue (sim setup not working, smallest watch I have access to is 41mm)
* Size 65.0 was validated on 41mm watch face for BG of "888" - trying size 60.0 as a hope it fixes for smaller watches