### PR TITLE
Separate testflight expiration from profile expiration

### DIFF
--- a/LoopCaregiver/LoopCaregiver/Views/Settings/AppExpirationAlerter.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Settings/AppExpirationAlerter.swift
@@ -219,7 +219,7 @@ class AppExpirationAlerter {
         if isTestFlight, let buildDate = buildDate() {
             let testflightExpiration = Calendar.current.date(byAdding: .day, value: 90, to: buildDate)!
 
-            return profileExpiration < testflightExpiration ? profileExpiration : testflightExpiration
+            return testflightExpiration
         } else {
             return profileExpiration
         }


### PR DESCRIPTION
This should remove the erroneous app expiration warning for browser build (and testflight-distributed Xcode builds?) that currently occur at the time a user's Apple distribution certificate expires, as discussed in this zulipchat: https://loop.zulipchat.com/#narrow/stream/358458-Loop-Caregiver-App/topic/why.20is.20the.20caregiver.20app.20prompting.20that.20I.20need.20to.20Update.20.2E.2E.2E/near/453395866

I have built this and installed on my phone as the caregiver.

This mirrors a change made to Loop: https://github.com/LoopKit/Loop/commit/b6610a1d44878e96b7898ebafbf40f2b6b4a6560