### PR TITLE
Provisioning profile support for Xcode 16

### DIFF
--- a/LoopCaregiver/Scripts/capture-build-details.sh
+++ b/LoopCaregiver/Scripts/capture-build-details.sh
@@ -25,17 +25,12 @@ info() {
 }
 
 info_plist_path="${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/BuildDetails.plist"
-provisioning_profile_path="${HOME}/Library/MobileDevice/Provisioning Profiles/${EXPANDED_PROVISIONING_PROFILE}.mobileprovision"
 xcode_build_version=${XCODE_PRODUCT_BUILD_VERSION:-$(xcodebuild -version | grep version | cut -d ' ' -f 3)}
 while [[ $# -gt 0 ]]
 do
   case $1 in
     -i|--info-plist-path)
       info_plist_path="${2}"
-      shift 2
-      ;;
-    -p|--provisioning-profile-path)
-      provisioning_profile_path="${2}"
       shift 2
       ;;
   esac
@@ -66,15 +61,6 @@ fi
 plutil -replace com-app-srcroot -string "${PWD}" "${info_plist_path}"
 plutil -replace com-app-build-date -string "$(date)" "${info_plist_path}"
 plutil -replace com-app-xcode-version -string "${xcode_build_version}" "${info_plist_path}"
-
-if [ -e "${provisioning_profile_path}" ]; then
-  profile_expire_date=$(security cms -D -i "${provisioning_profile_path}" | plutil -p - | grep ExpirationDate | cut -b 23-)
-  # Convert to plutil format
-  profile_expire_date=$(date -j -f "%Y-%m-%d %H:%M:%S" "${profile_expire_date}" +"%Y-%m-%dT%H:%M:%SZ")
-  plutil -replace com-app-profile-expiration -date "${profile_expire_date}" "${info_plist_path}"
-else
-  warn "Invalid provisioning profile path ${provisioning_profile_path}"
-fi
 
 # determine if this is a workspace build
 # if so, fill out the git revision and branch


### PR DESCRIPTION
Xcode 16 stores the provisioning profile in a new location from Xcode 15 and earlier versions, which renders the hardcoded path in Scripts/capture-build-details.sh ineffective. This PR resolves the issue by reading the provisioning profile at runtime and storing it in a cached constant within the BuildDetails class.

This PR copies the changes found in [LoopKit/Loop PR 2226](https://github.com/LoopKit/Loop/pull/2226).

It has been tested with Xcode 16 building LoopCaregiver.