### PR TITLE
Fix Xcode 26 layout issue in bolus and carb entry views

### DIFF
--- a/LoopCaregiver/LoopCaregiver/Views/Actions/BolusInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/BolusInputView.swift
@@ -85,29 +85,33 @@ struct BolusInputView: View {
         Form {
             if let recommendedBolus = remoteDataSource.recommendedBolus {
                 LabeledContent {
-                    Text(LocalizationUtils.presentableStringFromBolusAmount(recommendedBolus))
-                    Text("U")
-                        .frame(width: unitFrameWidth)
+                    HStack {
+                        Text(LocalizationUtils.presentableStringFromBolusAmount(recommendedBolus))
+                        Text("U")
+                            .frame(width: unitFrameWidth)
+                    }
                 } label: {
                     Text("Recommended Bolus")
                 }
             }
             LabeledContent {
-                TextField(
-                    "0",
-                    text: $bolusAmount
-                )
-                .multilineTextAlignment(.trailing)
-                .keyboardType(.decimalPad)
-                .focused($bolusInputViewIsFocused)
-                .onAppear(perform: {
-                    bolusInputViewIsFocused = true
-                    if let recommendedBolus = remoteDataSource.recommendedBolus {
-                        bolusAmount = LocalizationUtils.presentableStringFromBolusAmount(recommendedBolus)
-                    }
-                })
-                Text("U")
-                    .frame(width: unitFrameWidth)
+                HStack {
+                    TextField(
+                        "0",
+                        text: $bolusAmount
+                    )
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.decimalPad)
+                    .focused($bolusInputViewIsFocused)
+                    .onAppear(perform: {
+                        bolusInputViewIsFocused = true
+                        if let recommendedBolus = remoteDataSource.recommendedBolus {
+                            bolusAmount = LocalizationUtils.presentableStringFromBolusAmount(recommendedBolus)
+                        }
+                    })
+                    Text("U")
+                        .frame(width: unitFrameWidth)
+                }
             } label: {
                 Text("Bolus")
             }

--- a/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
+++ b/LoopCaregiver/LoopCaregiver/Views/Actions/CarbInputView.swift
@@ -90,18 +90,20 @@ struct CarbInputView: View {
     var carbEntryForm: some View {
         Form {
             LabeledContent {
-                TextField(
-                    "0",
-                    text: $carbInput
-                )
-                .multilineTextAlignment(.trailing)
-                .keyboardType(.decimalPad)
-                .focused($carbInputViewIsFocused)
-                .onAppear(perform: {
-                    carbInputViewIsFocused = true
-                })
-                Text("g")
-                    .frame(width: unitFrameWidth)
+                HStack {
+                    TextField(
+                        "0",
+                        text: $carbInput
+                    )
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.decimalPad)
+                    .focused($carbInputViewIsFocused)
+                    .onAppear(perform: {
+                        carbInputViewIsFocused = true
+                    })
+                    Text("g")
+                        .frame(width: unitFrameWidth)
+                }
             } label: {
                 Text("Amount Consumed")
             }
@@ -210,15 +212,17 @@ struct CarbInputView: View {
             }
             
             LabeledContent {
-                TextField(
-                    "",
-                    text: $absorption
-                )
-                .multilineTextAlignment(.trailing)
-                .keyboardType(.decimalPad)
-                .focused($absorptionInputFieldIsFocused)
-                Text("hr")
-                    .frame(width: unitFrameWidth)
+                HStack {
+                    TextField(
+                        "",
+                        text: $absorption
+                    )
+                    .multilineTextAlignment(.trailing)
+                    .keyboardType(.decimalPad)
+                    .focused($absorptionInputFieldIsFocused)
+                    Text("hr")
+                        .frame(width: unitFrameWidth)
+                }
             } label: {
                 Text("Absorption Time")
             }


### PR DESCRIPTION
[Issue 69](https://github.com/LoopKit/LoopCaregiver/issues/69)

## Summary

- Building with Xcode 26 caused layout issues in the bolus and carb entry views where the unit text (`U` and `g`) was not laying out next to the amount field
- Wrapped the amount `TextField`/`Text` and unit label in an `HStack` in both `BolusInputView` and `CarbInputView` to ensure proper side-by-side layout

See attached issue for broken views. Below is with this PR on a real device:

<img width="590" height="1278" alt="Screenshot 2026-03-16 at 8 20 03 PM" src="https://github.com/user-attachments/assets/3acc07eb-e139-435e-89cc-99d4957c3777" />
<img width="590" height="1278" alt="Screenshot 2026-03-16 at 8 19 48 PM" src="https://github.com/user-attachments/assets/d7506c37-f9be-4d26-8d8b-2927319af3a7" />