### PR TITLE
Fix inverted condition on the max glucose count log

### DIFF
--- a/LoopCaregiverKit/Sources/LoopCaregiverKit/Nightscout/NightscoutDataSource.swift
+++ b/LoopCaregiverKit/Sources/LoopCaregiverKit/Nightscout/NightscoutDataSource.swift
@@ -39,7 +39,7 @@ public class NightscoutDataSource: ObservableObject, RemoteDataServiceProvider {
             }
         })
         .map({ $0.toGlucoseSample() })
-        if result.count < maxFetchCount() {
+        if result.count >= maxFetchCount() {
             print("Hit max glucose count: Consider increasing")
         }
         return result


### PR DESCRIPTION
### The change

```diff
-        if result.count < maxFetchCount() {
+        if result.count >= maxFetchCount() {
             print("Hit max glucose count: Consider increasing")
         }
```

### Why

The condition was inverted in 6698b30 ("Remove assertion"), which rewrote

```swift
assert(result.count < maxFetchCount(), "Hit max count: Consider increasing")
```

as

```swift
if result.count < maxFetchCount() { print("Hit max glucose count: Consider increasing") }
```

`assert` fires when its condition is violated; the `if` fires when it holds.

`result.count` can never exceed `maxFetchCount()` —
`fetchGlucose(dateInterval:maxCount:)` passes `maxCount` through as Nightscout's
`count=` query parameter, and everything after it (`compactMap` into
`[GlucoseEntry]`, then a 1:1 `toGlucoseSample()`) can only shrink the array. So
the warning prints on every successful fetch and stays silent in exactly the
case it exists to report — a fetch truncated at the cap.

`>=` rather than `==` so it still reports a server that ignores `count=`.
Diagnostic only — `result` is returned unchanged.

### Testing

Built and tested against `dev` (fc86735), Xcode 26.2, iOS 26.2 simulator:
`LoopCaregiverKit` and the `LoopCaregiver` app scheme build clean, and
`LoopCaregiverKitTests` passes (9 tests, 0 failures).
